### PR TITLE
Make access and refresh token expiry time configurable in `.env`

### DIFF
--- a/packages/server/__tests__/auth/auth.test.js
+++ b/packages/server/__tests__/auth/auth.test.js
@@ -1,0 +1,88 @@
+process.env.AUTH_SECRET = "ABC123";
+
+const auth = require("../../auth");
+const { createAccessToken, createRefreshToken } = require("../config/mock-api");
+const next = jest.fn();
+
+describe("Authentication", () => {
+  it("works with a valid access token", () => {
+    const accessToken = createAccessToken(1);
+    const req = {
+      url: "https://qhacks.io/v1/auth",
+      headers: { authorization: `Bearer ${accessToken}` }
+    };
+    auth()(req, null, next);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(req.user).toEqual(
+      expect.objectContaining({ iss: "QHacks Authentication", userId: 1 })
+    );
+  });
+
+  it("fails for an invalid access token", () => {
+    const accessToken = "abc123";
+    const res = {};
+    const json = jest.fn();
+    res.status = jest.fn((a) => ({
+      json
+    }));
+
+    const req = {
+      url: "https://qhacks.io/v1/auth",
+      headers: { authorization: `Bearer ${accessToken}` }
+    };
+    auth()(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 401,
+        message: "Invalid token!",
+        type: "AUTHORIZATION"
+      })
+    );
+  });
+
+  it("fails for invalid headers", () => {
+    const res = {};
+    const json = jest.fn();
+    res.status = jest.fn((a) => ({
+      json
+    }));
+
+    const req = {
+      url: "https://qhacks.io/v1/auth",
+      headers: { authorization: `Ayy lmao` }
+    };
+    auth()(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 400,
+        message: "Missing auth token!",
+        type: "BAD_REQUEST"
+      })
+    );
+  });
+
+  it("fails when given a refresh token", () => {
+    const refreshToken = createRefreshToken(1);
+    const res = {};
+    const json = jest.fn();
+    res.status = jest.fn((a) => ({
+      json
+    }));
+
+    const req = {
+      url: "https://qhacks.io/v1/auth",
+      headers: { authorization: `Bearer ${refreshToken}` }
+    };
+    auth()(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 401,
+        message: "Invalid token!",
+        type: "AUTHORIZATION"
+      })
+    );
+  });
+});

--- a/packages/server/__tests__/config/mock-api.js
+++ b/packages/server/__tests__/config/mock-api.js
@@ -10,6 +10,7 @@ const auth = require("../../auth");
 const api = require("../../api");
 
 const app = express();
+const { AUTH_SECRET } = process.env;
 
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json({ limit: "50mb" }));
@@ -23,5 +24,17 @@ module.exports = {
       expiresIn: "5 minutes",
       issuer: "QHacks Authentication"
     });
-  }
+  },
+  createRefreshToken: (userId) =>
+    jwt.sign(
+      {
+        type: "refresh",
+        userId
+      },
+      AUTH_SECRET,
+      {
+        expiresIn: "60 minutes",
+        issuer: "QHacks Authentication"
+      }
+    )
 };

--- a/packages/server/controllers/auth.controller.js
+++ b/packages/server/controllers/auth.controller.js
@@ -8,8 +8,10 @@ const { ERROR_TEMPLATES, createError } = require("../errors");
 const { EMAILS, ERROR } = require("../strings");
 
 const JWT_ISSUER = "QHacks Authentication";
-const ACCESS_TOKEN_EXPIRE_TIME = "5 minutes";
-const REFRESH_TOKEN_EXPIRE_TIME = "60 minutes";
+const ACCESS_TOKEN_EXPIRE_TIME =
+  process.env.ACCESS_TOKEN_EXPIRE_TIME || "5 minutes";
+const REFRESH_TOKEN_EXPIRE_TIME =
+  process.env.REFRESH_TOKEN_EXPIRE_TIME || "60 minutes";
 const QHACKS_2018_SLUG = "qhacks-2018";
 
 const { AUTH_SECRET } = process.env;


### PR DESCRIPTION
## Proposed Change
Allow `ACCESS_TOKEN_EXPIRE_TIME` and `REFRESH_TOKEN_EXPIRE_TIME` to be overriden in `.env`. This will allow us to have longer lasting access tokens for using our API in the hackathon

### How did you do this?
Added logic so that the server will first check the `.env` for these values, then default to the original hardcoded values.

### Why are you choosing this approach?
This will allow us to set refresh time to something like 72 hours, which would allow people to use our API for the duration of the hackathon without worrying about refreshing their tokens.

### Any open questions you want to ask code reviewers?
Nope!

### List of changes:

  - Add access and refresh token expiry time options to `.env`.
  - Add tests to authentication middleware.

## Pull Request Checklist:

  - [X] My submission passes all tests.
  - [X] I have lint my code locally prior to submission.
  - [X] I have written new tests for my core changes (where applicable).
  - [X] I have referenced all useful information (issues, tasks, etc) in the pull request.

