### PR TITLE
Update jest config to show proper coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -18,6 +18,6 @@ module.exports = {
     }
   ],
   coverageDirectory: "./coverage",
-  coveragePathIgnorePatterns: ["/node_modules/"],
+  collectCoverageFrom: ["**/*.js", "!**/node_modules/**", "!**/*.config.js", "!**/__tests__/**", "./packages/**/*.js"],
   coverageReporters: ["lcov"]
 };


### PR DESCRIPTION
## Proposed Change

Related PR: #150 

Update jest config (yet again 🃏) so that coverage is corrected properly. Currently, coverage is only reported for the files that have tests written for them, which is inflating our coverage and not giving us a real idea of how much coverage we actually have.

### How did you do this?
Get rid of `coverageIgnorePatterns` and instead use `collectCoverageFrom` in `jest.config.js` so it includes untested files

### Why are you choosing this approach?
So that our coverage is accurate

### Any open questions you want to ask code reviewers?
Do you agree with the directories from which we are collecting coverage? Are there any that should be added/removed?

### List of changes:
  - Update jest config to collect proper coverage

## Pull Request Checklist:

  - [x] My submission passes all tests.
  - [x] I have lint my code locally prior to submission.
  - [x] I have written new tests for my core changes (where applicable).
  - [x] I have referenced all useful information (issues, tasks, etc) in the pull request.

