### PR TITLE
Add variable to semantic config to fix build

### DIFF
--- a/packages/client/assets/semantic-ui/theme.config
+++ b/packages/client/assets/semantic-ui/theme.config
@@ -33,6 +33,7 @@
 @label      : 'default';
 @list       : 'default';
 @loader     : 'default';
+@placeholder: 'default';
 @rail       : 'default';
 @reveal     : 'default';
 @segment    : 'default';


### PR DESCRIPTION
## Proposed Change

This adds a variable to the semantic theme config, without this variable our builds were failing!

The error we were getting is described in this issue: https://github.com/3nvi/webpack2-semantic-ui-theming/issues/1

### How did you do this?

Add the `@placeholder` variable in the semantic-ui config!

### Why are you choosing this approach?

Fix failing builds 😄 

### Any open questions you want to ask code reviewers?

Nope!

### List of changes:

  - Add the `@placeholder` variable to semantic config

## Pull Request Checklist:

  - [x] My submission passes all tests.
  - [x] I have lint my code locally prior to submission.
  - [x] I have written new tests for my core changes (where applicable).
  - [x] I have referenced all useful information (issues, tasks, etc) in the pull request.

