### PR TITLE
Add CORS to subscribe endpoint

### DIFF
--- a/packages/server/api/v1/routes/subscribe.routes.js
+++ b/packages/server/api/v1/routes/subscribe.routes.js
@@ -1,4 +1,5 @@
 const Router = require("express").Router;
+const cors = require("cors");
 
 const SUBSCRIBE = "subscribe";
 
@@ -8,7 +9,7 @@ module.exports = (ctr) => {
   // Get subscribe controller
   const { subscribe } = ctr;
 
-  subscribeAPI.post(`/${SUBSCRIBE}/`, (req, res) => {
+  subscribeAPI.post(`/${SUBSCRIBE}/`, cors(), (req, res) => {
     const { event, name, email } = req.body;
     subscribe
       .addMailingListSubscription(event, name, email)

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -20,6 +20,7 @@
     "camelcase": "^5.0.0",
     "compression": "^1.7.3",
     "connect-history-api-fallback": "^1.5.0",
+    "cors": "^2.8.4",
     "dotenv": "^6.0.0",
     "express": "^4.16.3",
     "helmet": "^3.13.0",


### PR DESCRIPTION
## Proposed Change

Fixes: Issue where the website frontend was unable to read the body of API request responses do to CORS being disabled on that endpoint

### How did you do this?

Enable CORS on the subscribe endpoint

### Why are you choosing this approach?

In order to read the response body

### Any open questions you want to ask code reviewers?

Nope

### List of changes:

  - Add CORS to endpoint

## Pull Request Checklist:

  - [x] My submission passes all tests.
  - [x] I have lint my code locally prior to submission.
  - [x] I have written new tests for my core changes (where applicable).
  - [x] I have referenced all useful information (issues, tasks, etc) in the pull request.

