### PR TITLE
Add application abilities to GraphQL API

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,6 +13,7 @@ module.exports = {
         dbName: "qhacks-dashboard-test"
       },
       setupTestFrameworkScriptFile: "./packages/server/__tests__/config/test-framework",
+      setupFiles: ["./packages/server/__tests__/config/set-up"],
       testRegex: "./packages/server/__tests__\/.*\.test\.js$"
     }
   ],

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,7 +13,7 @@ module.exports = {
         dbName: "qhacks-dashboard-test"
       },
       setupTestFrameworkScriptFile: "./packages/server/__tests__/config/test-framework",
-      testRegex: "./packages/server/__tests__\/.*\.test\.js$",
+      testRegex: "./packages/server/__tests__\/.*\.test\.js$"
     }
   ],
   coverageDirectory: "./coverage",

--- a/packages/server/__tests__/config/mock-api.js
+++ b/packages/server/__tests__/config/mock-api.js
@@ -1,0 +1,82 @@
+process.env.AUTH_SECRET = "ABC123";
+
+const request = require("supertest");
+
+const { GraphQLAuthenticationError } = require("../../errors");
+const { ApolloServer } = require("apollo-server-express");
+const compression = require("compression");
+const bodyParser = require("body-parser");
+
+const db = require("./mock-db");
+const { verifyAccessToken } = require("../../oauth")(db);
+const express = require("express");
+const helmet = require("helmet");
+const cors = require("cors");
+const jwt = require("jsonwebtoken");
+
+const resolvers = require("../../gql/resolvers");
+const typeDefs = require("../../gql/definitions");
+
+const app = express();
+
+// Third Party Middleware
+app.use(cors());
+app.use(helmet());
+app.use(compression());
+app.use(bodyParser.json({ limit: "50mb" }));
+app.use(bodyParser.urlencoded({ extended: true }));
+
+// Protected GraphQL Endpoint
+const graphqlServer = new ApolloServer({
+  typeDefs,
+  resolvers,
+  context: async ({ req, res }) => {
+    try {
+      const { user, access } = await verifyAccessToken(req);
+
+      return {
+        db,
+        user,
+        access
+      };
+    } catch (err) {
+      throw new GraphQLAuthenticationError("Invalid access token!");
+    }
+  },
+  formatError: (error) => {
+    console.log(error);
+    return error;
+  }
+});
+
+// Apply Express Middleware
+graphqlServer.applyMiddleware({ app });
+
+// Creates an access token for testing
+function createMockAccessToken(userId) {
+  return jwt.sign(
+    {
+      userId
+    },
+    process.env.AUTH_SECRET,
+    {
+      expiresIn: 300,
+      issuer: "QHacks Testing"
+    }
+  );
+}
+
+module.exports = {
+  /**
+   * Make a GraphQL Request to the mock API
+   * userId is provided to create an access token
+   */
+  gql(userId, query) {
+    const accessToken = createMockAccessToken(userId);
+    return request(app)
+      .post("/graphql")
+      .set("authorization", `Bearer ${accessToken}`)
+      .send({ operationName: null, query, variables: {} })
+      .then(({ body }) => body);
+  }
+};

--- a/packages/server/__tests__/config/mock-api.js
+++ b/packages/server/__tests__/config/mock-api.js
@@ -42,10 +42,6 @@ const graphqlServer = new ApolloServer({
     } catch (err) {
       throw new GraphQLAuthenticationError("Invalid access token!");
     }
-  },
-  formatError: (error) => {
-    console.log(error);
-    return error;
   }
 });
 

--- a/packages/server/__tests__/config/set-up.js
+++ b/packages/server/__tests__/config/set-up.js
@@ -1,0 +1,5 @@
+const { sequelize } = require("./mock-db");
+
+module.exports = async () => {
+  await sequelize.sync({ force: true });
+};

--- a/packages/server/__tests__/config/test-framework.js
+++ b/packages/server/__tests__/config/test-framework.js
@@ -105,11 +105,42 @@ beforeEach(async () => {
     ]
   );
 
-  await Application.create({
+  const applicationFields = await ApplicationField.bulkCreate([
+    {
+      eventId: QHACKS_EVENT_ID,
+      type: "CHECKBOX",
+      label: "Field 1",
+      required: true
+    },
+    {
+      eventId: QHACKS_EVENT_ID,
+      type: "CHECKBOX",
+      label: "Field 2",
+      required: false
+    },
+    {
+      eventId: QHACKS_EVENT_ID,
+      type: "CHECKBOX",
+      label: "Field 3",
+      required: true
+    }
+  ]);
+
+  const { id: applicationId } = await Application.create({
     eventId: QHACKS_EVENT_ID,
     userId: HACKER_ID,
     status: "APPLIED"
   });
+
+  const applicationFieldResponses = applicationFields.map(
+    ({ id: applicationFieldId }, i) => ({
+      applicationFieldId,
+      applicationId,
+      answer: `Test answer ${i}`
+    })
+  );
+
+  await ApplicationFieldResponse.bulkCreate(applicationFieldResponses);
 });
 
 afterEach(() => {

--- a/packages/server/__tests__/config/test-framework.js
+++ b/packages/server/__tests__/config/test-framework.js
@@ -28,6 +28,9 @@ const {
 const QHACKS_CLIENT_ID = uuid.v4();
 const QHACKS_EVENT_ID = uuid.v4();
 const HACKER_ID = uuid.v4();
+const TOMORROW = new Date();
+
+TOMORROW.setDate(new Date().getDate() + 1);
 
 beforeAll(async () => {
   await sequelize.sync({ force: true });
@@ -41,8 +44,8 @@ beforeEach(async () => {
     startDate: new Date("2019-02-01T19:00Z"),
     endDate: new Date("2019-02-03T19:00Z"),
     requiresApplication: true,
-    applicationOpenDate: new Date("2018-12-01"),
-    applicationCloseDate: new Date("2019-01-10"),
+    applicationOpenDate: new Date("1970-01-01"),
+    applicationCloseDate: TOMORROW,
     hasProjectSubmissions: true,
     projectSubmissionDate: new Date("2018-02-03T14:00Z"),
     eventLogoUrl: "http://digitalocean.com/qhacks.jpg"

--- a/packages/server/__tests__/config/test-framework.js
+++ b/packages/server/__tests__/config/test-framework.js
@@ -24,20 +24,17 @@ const {
   User,
   sequelize
 } = require("./mock-db");
+const { getDefaultScopes } = require("../../oauth/scopes");
 
 const QHACKS_CLIENT_ID = uuid.v4();
 const QHACKS_EVENT_ID = uuid.v4();
 const HACKER_ID = uuid.v4();
-
-const { getDefaultScopes } = require("../../oauth/scopes");
-const DEFAULT_SCOPES = JSON.stringify(getDefaultScopes("HACKER"));
-
 const TOMORROW = new Date();
 
 TOMORROW.setDate(new Date().getDate() + 1);
 
 beforeAll(async () => {
-  await sequelize.sync({ force: true });
+  await sequelize.sync();
 });
 
 beforeEach(async () => {
@@ -107,7 +104,7 @@ beforeEach(async () => {
     [
       { role: "ADMIN" },
       { role: "VOLUNTEER" },
-      { role: "HACKER", scopes: JSON.stringify(["hacker:read"]) },
+      { role: "HACKER" },
       { role: "HACKER" }
     ]
   );
@@ -182,7 +179,8 @@ afterEach(() => {
         Event.destroy({ where: {} }),
         Location.destroy({ where: {} })
       ])
-    );
+    )
+    .catch((err) => console.log(err));
 });
 
 afterAll(async () => {
@@ -193,7 +191,7 @@ afterAll(async () => {
 async function createUsers(users, options) {
   const oauthUsers = users.map((_, i) => ({
     role: options[i].role,
-    scopes: options[i].scope || DEFAULT_SCOPES
+    scopes: options[i].scope || JSON.stringify(getDefaultScopes("HACKER"))
   }));
 
   const savedOAuthUsers = await OAuthUser.bulkCreate(oauthUsers);

--- a/packages/server/__tests__/config/test-framework.js
+++ b/packages/server/__tests__/config/test-framework.js
@@ -28,6 +28,10 @@ const {
 const QHACKS_CLIENT_ID = uuid.v4();
 const QHACKS_EVENT_ID = uuid.v4();
 const HACKER_ID = uuid.v4();
+
+const { getDefaultScopes } = require("../../oauth/scopes");
+const DEFAULT_SCOPES = JSON.stringify(getDefaultScopes("HACKER"));
+
 const TOMORROW = new Date();
 
 TOMORROW.setDate(new Date().getDate() + 1);
@@ -187,8 +191,6 @@ afterAll(async () => {
 
 // Create necessary relationships for users
 async function createUsers(users, options) {
-  const DEFAULT_SCOPES = JSON.stringify(["hacker:read"]);
-
   const oauthUsers = users.map((_, i) => ({
     role: options[i].role,
     scopes: options[i].scope || DEFAULT_SCOPES

--- a/packages/server/__tests__/config/test-framework.js
+++ b/packages/server/__tests__/config/test-framework.js
@@ -86,9 +86,23 @@ beforeEach(async () => {
         phoneNumber: "(123)-456-789",
         schoolName: "Queen's",
         password: "password"
+      },
+      {
+        firstName: "Hacker",
+        lastName: "1",
+        dateOfBirth: new Date(),
+        email: "hacker1@gmail.com",
+        phoneNumber: "(123)-456-789",
+        schoolName: "Queen's",
+        password: "password"
       }
     ],
-    [{ role: "ADMIN" }, { role: "VOLUNTEER" }, { role: "HACKER" }]
+    [
+      { role: "ADMIN" },
+      { role: "VOLUNTEER" },
+      { role: "HACKER", scopes: JSON.stringify(["hacker:read"]) },
+      { role: "HACKER" }
+    ]
   );
 
   await Application.create({
@@ -139,13 +153,11 @@ afterAll(async () => {
 
 // Create necessary relationships for users
 async function createUsers(users, options) {
-  const scopes = users.map(() =>
-    JSON.stringify([{ user: "read", user: "write" }])
-  );
+  const DEFAULT_SCOPES = JSON.stringify(["hacker:read"]);
 
   const oauthUsers = users.map((_, i) => ({
     role: options[i].role,
-    scopes: scopes[i]
+    scopes: options[i].scope || DEFAULT_SCOPES
   }));
 
   const savedOAuthUsers = await OAuthUser.bulkCreate(oauthUsers);

--- a/packages/server/__tests__/gql/resolvers/interfaces/User.test.js
+++ b/packages/server/__tests__/gql/resolvers/interfaces/User.test.js
@@ -19,7 +19,7 @@ describe("User Interface", () => {
           }
         }
       }
-    `
+      `
     );
 
     expect(data).toEqual({

--- a/packages/server/__tests__/gql/resolvers/interfaces/User.test.js
+++ b/packages/server/__tests__/gql/resolvers/interfaces/User.test.js
@@ -1,16 +1,12 @@
 const { gql } = require("../../../config/mock-api");
-const {
-  User,
-  Application,
-  ApplicationField
-} = require("../../../config/mock-db");
+const { User } = require("../../../config/mock-db");
 
 describe("User Interface", () => {
   it("returns data about the current user", async () => {
     const { id: userId } = await User.findOne({
       where: { email: "ross.hill@rosshill.ca" }
     });
-    const { data, errors } = await gql(
+    const { data } = await gql(
       userId,
       `
       {

--- a/packages/server/__tests__/gql/resolvers/interfaces/User.test.js
+++ b/packages/server/__tests__/gql/resolvers/interfaces/User.test.js
@@ -10,7 +10,7 @@ describe("User Interface", () => {
     const { id: userId } = await User.findOne({
       where: { email: "ross.hill@rosshill.ca" }
     });
-    const { data } = await gql(
+    const { data, errors } = await gql(
       userId,
       `
       {

--- a/packages/server/__tests__/gql/resolvers/interfaces/User.test.js
+++ b/packages/server/__tests__/gql/resolvers/interfaces/User.test.js
@@ -1,0 +1,38 @@
+const { gql } = require("../../../config/mock-api");
+const {
+  User,
+  Application,
+  ApplicationField
+} = require("../../../config/mock-db");
+
+describe("User Interface", () => {
+  it("returns data about the current user", async () => {
+    const { id: userId } = await User.findOne({
+      where: { email: "ross.hill@rosshill.ca" }
+    });
+    const { data } = await gql(
+      userId,
+      `
+      {
+        user {
+          firstName
+          lastName
+          email
+          oauthInfo {
+            role
+          }
+        }
+      }
+    `
+    );
+
+    expect(data).toEqual({
+      user: {
+        firstName: "Ross",
+        lastName: "Hill",
+        email: "ross.hill@rosshill.ca",
+        oauthInfo: { role: "ADMIN" }
+      }
+    });
+  });
+});

--- a/packages/server/__tests__/gql/resolvers/types/Application.test.js
+++ b/packages/server/__tests__/gql/resolvers/types/Application.test.js
@@ -1,0 +1,97 @@
+const { gql } = require("../../../config/mock-api");
+const {
+  User,
+  Application,
+  ApplicationField
+} = require("../../../config/mock-db");
+
+describe("Application Type", () => {
+  it("returns the current user's application", async () => {
+    const { id: userId } = await User.findOne({
+      where: { email: "jmichaelt98@gmail.com" }
+    });
+
+    const { data: response } = await gql(
+      userId,
+      `
+      {
+        application(event: "qhacks-2019") {
+          status
+          response {
+            label
+            answer
+          }
+        }
+      }
+    `
+    );
+
+    expect(response.application.status).toBe("APPLIED");
+    expect(response.application.response).toHaveLength(3);
+
+    response.application.response.forEach(({ label, answer }) => {
+      expect(label).toBeDefined();
+      expect(label).toContain("Field");
+      expect(answer).toBeDefined();
+      expect(answer).toContain("Test answer");
+    });
+  });
+
+  it("creates a new application for a user", async () => {
+    const { id: userId } = await User.findOne({
+      where: { email: "hacker1@gmail.com" }
+    });
+
+    const { data } = await gql(
+      userId,
+      `
+      mutation {
+        createApplication(event: "qhacks-2019", input: {
+          response: [
+            {
+              label: "Field 1",
+              answer: "answer1"
+            },
+            {
+              label: "Field 2",
+              answer: "answer2"
+            },
+            {
+              label: "Field 3",
+              answer: "answer3"
+            }
+          ]
+        }) {
+          application {
+            status
+            response {
+              label
+              answer
+            }
+          }
+        }
+      }
+    `
+    );
+
+    expect(data.createApplication.application.status).toBe("APPLIED");
+    expect(data.createApplication.application.response).toHaveLength(3);
+
+    data.createApplication.application.response.forEach(
+      ({ label, answer }, i) => {
+        expect(label).toBe(`Field ${i + 1}`);
+        expect(answer).toBe(`answer${i + 1}`);
+      }
+    );
+
+    const dbResponse = await Application.findOne({
+      where: { userId },
+      include: ApplicationField
+    });
+
+    expect(dbResponse.ApplicationFields).toHaveLength(3);
+    dbResponse.ApplicationFields.forEach((field) => {
+      expect(field.ApplicationFieldResponse.answer).toContain("answer");
+    });
+  });
+});

--- a/packages/server/__tests__/gql/resolvers/types/Application.test.js
+++ b/packages/server/__tests__/gql/resolvers/types/Application.test.js
@@ -18,19 +18,19 @@ describe("Application Type", () => {
       {
         application(eventSlug: "qhacks-2019") {
           status
-          response {
+          responses {
             label
             answer
           }
         }
       }
-    `
+      `
     );
 
     expect(response.application.status).toBe("APPLIED");
-    expect(response.application.response).toHaveLength(3);
+    expect(response.application.responses).toHaveLength(3);
 
-    response.application.response.forEach(({ label, answer }) => {
+    response.application.responses.forEach(({ label, answer }) => {
       expect(label).toBeDefined();
       expect(label).toContain("Field");
       expect(answer).toBeDefined();
@@ -48,7 +48,7 @@ describe("Application Type", () => {
       `
       mutation {
         createApplication(eventSlug: "qhacks-2019", input: {
-          response: [
+          responses: [
             {
               label: "Field 1",
               answer: "answer1"
@@ -65,7 +65,7 @@ describe("Application Type", () => {
         }) {
           application {
             status
-            response {
+            responses {
               label
               answer
             }
@@ -76,9 +76,9 @@ describe("Application Type", () => {
     );
 
     expect(data.createApplication.application.status).toBe("APPLIED");
-    expect(data.createApplication.application.response).toHaveLength(3);
+    expect(data.createApplication.application.responses).toHaveLength(3);
 
-    data.createApplication.application.response.forEach(
+    data.createApplication.application.responses.forEach(
       ({ label, answer }, i) => {
         expect(label).toBe(`Field ${i + 1}`);
         expect(answer).toBe(`answer${i + 1}`);
@@ -106,7 +106,7 @@ describe("Application Type", () => {
       `
       mutation {
         createApplication(eventSlug: "qhacks-2019", input: {
-          response: [
+          responses: [
             {
               label: "Field 1",
               answer: "answer1"
@@ -123,7 +123,7 @@ describe("Application Type", () => {
         }) {
           application {
             status
-            response {
+            responses {
               label
               answer
             }
@@ -161,7 +161,7 @@ describe("Application Type", () => {
       `
       mutation {
         createApplication(eventSlug: "yophacks-2019", input: {
-          response: [
+          responses: [
             {
               label: "Field 1",
               answer: "answer1"
@@ -174,7 +174,7 @@ describe("Application Type", () => {
         }) {
           application {
             status
-            response {
+            responses {
               label
               answer
             }
@@ -214,7 +214,7 @@ describe("Application Type", () => {
       `
       mutation {
         createApplication(eventSlug: "yophacks-2019", input: {
-          response: [
+          responses: [
             {
               label: "Field 1",
               answer: "answer1"
@@ -227,7 +227,7 @@ describe("Application Type", () => {
         }) {
           application {
             status
-            response {
+            responses {
               label
               answer
             }
@@ -254,7 +254,7 @@ describe("Application Type", () => {
       `
       mutation {
         createApplication(eventSlug: "qhacks-2019", input: {
-          response: [
+          responses: [
             {
               label: "Field 1",
               answer: "answer1"
@@ -271,7 +271,7 @@ describe("Application Type", () => {
         }) {
           application {
             status
-            response {
+            responses {
               label
               answer
             }
@@ -282,9 +282,9 @@ describe("Application Type", () => {
     );
 
     expect(data.createApplication.application.status).toBe("APPLIED");
-    expect(data.createApplication.application.response).toHaveLength(3);
+    expect(data.createApplication.application.responses).toHaveLength(3);
 
-    data.createApplication.application.response.forEach(
+    data.createApplication.application.responses.forEach(
       ({ label, answer }, i) => {
         expect(label).toBe(`Field ${i + 1}`);
         expect(answer).toBe(`answer${i + 1}`);
@@ -313,7 +313,7 @@ describe("Application Type", () => {
       `
       mutation {
         createApplication(eventSlug: "qhacks-2019", input: {
-          response: [
+          responses: [
             {
               label: "Field 1",
               answer: "answer1"
@@ -326,7 +326,7 @@ describe("Application Type", () => {
         }) {
           application {
             status
-            response {
+            responses {
               label
               answer
             }

--- a/packages/server/__tests__/gql/resolvers/types/Application.test.js
+++ b/packages/server/__tests__/gql/resolvers/types/Application.test.js
@@ -1,6 +1,7 @@
 const { gql } = require("../../../config/mock-api");
 const {
   User,
+  Event,
   Application,
   ApplicationField
 } = require("../../../config/mock-db");
@@ -93,5 +94,250 @@ describe("Application Type", () => {
     dbResponse.ApplicationFields.forEach((field) => {
       expect(field.ApplicationFieldResponse.answer).toContain("answer");
     });
+  });
+
+  it("validates form fields when creating an applciation", async () => {
+    const { id: userId } = await User.findOne({
+      where: { email: "hacker1@gmail.com" }
+    });
+
+    const { data, errors } = await gql(
+      userId,
+      `
+      mutation {
+        createApplication(event: "qhacks-2019", input: {
+          response: [
+            {
+              label: "Field 1",
+              answer: "answer1"
+            },
+            {
+              label: "Field 2",
+              answer: "answer2"
+            },
+            {
+              label: "Invalid Field",
+              answer: "answer3"
+            }
+          ]
+        }) {
+          application {
+            status
+            response {
+              label
+              answer
+            }
+          }
+        }
+      }
+    `
+    );
+
+    expect(data).toBeNull();
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toBe(
+      "Invalid Field is not a valid field for qhacks-2019"
+    );
+  });
+
+  it("validates if an event requires applications", async () => {
+    await Event.create({
+      name: "yophacks-2019",
+      slug: "yophacks-2019",
+      startDate: new Date("2019-02-01T19:00Z"),
+      endDate: new Date("2019-02-03T19:00Z"),
+      requiresApplication: false,
+      hasProjectSubmissions: true,
+      projectSubmissionDate: new Date("2018-02-03T14:00Z"),
+      eventLogoUrl: "http://digitalocean.com/yophacks.jpg"
+    });
+
+    const { id: userId } = await User.findOne({
+      where: { email: "hacker1@gmail.com" }
+    });
+
+    const { data, errors } = await gql(
+      userId,
+      `
+      mutation {
+        createApplication(event: "yophacks-2019", input: {
+          response: [
+            {
+              label: "Field 1",
+              answer: "answer1"
+            },
+            {
+              label: "Field 2",
+              answer: "answer2"
+            }
+          ]
+        }) {
+          application {
+            status
+            response {
+              label
+              answer
+            }
+          }
+        }
+      }
+    `
+    );
+
+    expect(data).toBeNull();
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toBe(
+      "yophacks-2019 does not require applications"
+    );
+  });
+
+  it("validates that the application has been submitted within the allowed dates", async () => {
+    const { id: userId } = await User.findOne({
+      where: { email: "hacker1@gmail.com" }
+    });
+
+    await Event.create({
+      name: "yophacks-2019",
+      slug: "yophacks-2019",
+      startDate: new Date("2019-02-01T19:00Z"),
+      endDate: new Date("2019-02-03T19:00Z"),
+      requiresApplication: true,
+      applicationOpenDate: new Date("1970-01-01"),
+      applicationCloseDate: new Date("1970-01-02"),
+      hasProjectSubmissions: true,
+      projectSubmissionDate: new Date("2018-02-03T14:00Z"),
+      eventLogoUrl: "http://digitalocean.com/yophacks.jpg"
+    });
+
+    const { data, errors } = await gql(
+      userId,
+      `
+      mutation {
+        createApplication(event: "yophacks-2019", input: {
+          response: [
+            {
+              label: "Field 1",
+              answer: "answer1"
+            },
+            {
+              label: "Field 2",
+              answer: "answer2"
+            }
+          ]
+        }) {
+          application {
+            status
+            response {
+              label
+              answer
+            }
+          }
+        }
+      }
+    `
+    );
+
+    expect(data).toBeNull();
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toBe(
+      "yophacks-2019 is not accepting applications at this time"
+    );
+  });
+
+  it("creates a new application for a user", async () => {
+    const { id: userId } = await User.findOne({
+      where: { email: "hacker1@gmail.com" }
+    });
+
+    const { data } = await gql(
+      userId,
+      `
+      mutation {
+        createApplication(event: "qhacks-2019", input: {
+          response: [
+            {
+              label: "Field 1",
+              answer: "answer1"
+            },
+            {
+              label: "Field 2",
+              answer: "answer2"
+            },
+            {
+              label: "Field 3",
+              answer: "answer3"
+            }
+          ]
+        }) {
+          application {
+            status
+            response {
+              label
+              answer
+            }
+          }
+        }
+      }
+    `
+    );
+
+    expect(data.createApplication.application.status).toBe("APPLIED");
+    expect(data.createApplication.application.response).toHaveLength(3);
+
+    data.createApplication.application.response.forEach(
+      ({ label, answer }, i) => {
+        expect(label).toBe(`Field ${i + 1}`);
+        expect(answer).toBe(`answer${i + 1}`);
+      }
+    );
+
+    const dbResponse = await Application.findOne({
+      where: { userId },
+      include: ApplicationField
+    });
+
+    expect(dbResponse.ApplicationFields).toHaveLength(3);
+    dbResponse.ApplicationFields.forEach((field) => {
+      expect(field.ApplicationFieldResponse.answer).toContain("answer");
+    });
+  });
+
+  it("validates required sign up fields", async () => {
+    const { id: userId } = await User.findOne({
+      where: { email: "hacker1@gmail.com" }
+    });
+
+    // Missing Field 3, which is required
+    const { data, errors } = await gql(
+      userId,
+      `
+      mutation {
+        createApplication(event: "qhacks-2019", input: {
+          response: [
+            {
+              label: "Field 1",
+              answer: "answer1"
+            },
+            {
+              label: "Field 2",
+              answer: "answer2"
+            }
+          ]
+        }) {
+          application {
+            status
+            response {
+              label
+              answer
+            }
+          }
+        }
+      }
+    `
+    );
+
+    expect(data).toBeNull();
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toBe("Field 3 is a required field!");
   });
 });

--- a/packages/server/__tests__/gql/resolvers/types/Application.test.js
+++ b/packages/server/__tests__/gql/resolvers/types/Application.test.js
@@ -16,7 +16,7 @@ describe("Application Type", () => {
       userId,
       `
       {
-        application(event: "qhacks-2019") {
+        application(eventSlug: "qhacks-2019") {
           status
           response {
             label
@@ -47,7 +47,7 @@ describe("Application Type", () => {
       userId,
       `
       mutation {
-        createApplication(event: "qhacks-2019", input: {
+        createApplication(eventSlug: "qhacks-2019", input: {
           response: [
             {
               label: "Field 1",
@@ -105,7 +105,7 @@ describe("Application Type", () => {
       userId,
       `
       mutation {
-        createApplication(event: "qhacks-2019", input: {
+        createApplication(eventSlug: "qhacks-2019", input: {
           response: [
             {
               label: "Field 1",
@@ -160,7 +160,7 @@ describe("Application Type", () => {
       userId,
       `
       mutation {
-        createApplication(event: "yophacks-2019", input: {
+        createApplication(eventSlug: "yophacks-2019", input: {
           response: [
             {
               label: "Field 1",
@@ -213,7 +213,7 @@ describe("Application Type", () => {
       userId,
       `
       mutation {
-        createApplication(event: "yophacks-2019", input: {
+        createApplication(eventSlug: "yophacks-2019", input: {
           response: [
             {
               label: "Field 1",
@@ -253,7 +253,7 @@ describe("Application Type", () => {
       userId,
       `
       mutation {
-        createApplication(event: "qhacks-2019", input: {
+        createApplication(eventSlug: "qhacks-2019", input: {
           response: [
             {
               label: "Field 1",
@@ -312,7 +312,7 @@ describe("Application Type", () => {
       userId,
       `
       mutation {
-        createApplication(event: "qhacks-2019", input: {
+        createApplication(eventSlug: "qhacks-2019", input: {
           response: [
             {
               label: "Field 1",

--- a/packages/server/__tests__/gql/resolvers/types/Hacker.test.js
+++ b/packages/server/__tests__/gql/resolvers/types/Hacker.test.js
@@ -1,0 +1,39 @@
+const { gql } = require("../../../config/mock-api");
+const { User } = require("../../../config/mock-db");
+
+describe("Hacker Type", () => {
+  it("queries individual hackers", async () => {
+    const { id: userId } = await User.findOne({
+      where: {
+        email: "jmichaelt98@gmail.com"
+      }
+    });
+
+    const { id: hackerId } = await User.findOne({
+      where: {
+        email: "hacker1@gmail.com"
+      }
+    });
+
+    const { data } = await gql(
+      userId,
+      `
+        {
+          hacker(id: "${hackerId}") {
+            firstName
+            lastName
+            email
+          }
+        }
+      `
+    );
+
+    expect(data).toEqual({
+      hacker: {
+        firstName: "Hacker",
+        lastName: "1",
+        email: "hacker1@gmail.com"
+      }
+    });
+  });
+});

--- a/packages/server/db/models/application-field-response.js
+++ b/packages/server/db/models/application-field-response.js
@@ -3,8 +3,7 @@ module.exports = (sequelize, DataTypes) => {
     "ApplicationFieldResponse",
     {
       answer: {
-        type: DataTypes.STRING,
-        allowNull: false
+        type: DataTypes.STRING
       }
     }
   );

--- a/packages/server/db/models/application-field-response.js
+++ b/packages/server/db/models/application-field-response.js
@@ -3,7 +3,7 @@ module.exports = (sequelize, DataTypes) => {
     "ApplicationFieldResponse",
     {
       answer: {
-        type: DataTypes.STRING
+        type: DataTypes.TEXT
       }
     }
   );

--- a/packages/server/db/models/application.js
+++ b/packages/server/db/models/application.js
@@ -9,7 +9,13 @@ module.exports = (sequelize, DataTypes) => {
       }
     },
     status: {
-      type: DataTypes.ENUM("APPLIED", "WAITING_LIST", "ACCEPTED", "REJECTED"),
+      type: DataTypes.ENUM(
+        "APPLIED",
+        "WAITING_LIST",
+        "ACCEPTED",
+        "REJECTED",
+        "WITHDRAWN"
+      ),
       allowNull: true
     },
     submissionDate: {

--- a/packages/server/db/models/event.js
+++ b/packages/server/db/models/event.js
@@ -77,6 +77,8 @@ module.exports = (sequelize, DataTypes) => {
     EventSponsor,
     Activity,
     User,
+    Application,
+    ApplicationField,
     EventCheckIn,
     MailingList,
     Speaker,
@@ -93,6 +95,10 @@ module.exports = (sequelize, DataTypes) => {
       foreignKey: "eventId",
       otherKey: "sponsorId"
     });
+
+    Event.hasMany(Application, DEFAULT_HAS_MANY_OPTIONS);
+
+    Event.hasMany(ApplicationField, DEFAULT_HAS_MANY_OPTIONS);
 
     Event.hasMany(Activity, DEFAULT_HAS_MANY_OPTIONS);
 

--- a/packages/server/db/models/mailing-list-subscription.js
+++ b/packages/server/db/models/mailing-list-subscription.js
@@ -14,7 +14,8 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.STRING,
         allowNull: false,
         validate: {
-          isEmail: true
+          isEmail: true,
+          isLowercase: true
         }
       }
     },

--- a/packages/server/errors/index.js
+++ b/packages/server/errors/index.js
@@ -87,6 +87,12 @@ class OAuthInvalidRefreshTokenError extends RestApiError {
   }
 }
 
+class GraphQLNotFoundError extends ApolloError {
+  constructor(message) {
+    super(message || "Unable to retrieve the requested resource");
+  }
+}
+
 module.exports = {
   RestApiError,
   ValidationError,
@@ -100,6 +106,7 @@ module.exports = {
   GraphQLAuthenticationError,
   GraphQLForbiddenError,
   GraphQLUserInputError,
+  GraphQLNotFoundError,
 
   DatabaseError,
   NotFoundError

--- a/packages/server/errors/index.js
+++ b/packages/server/errors/index.js
@@ -89,7 +89,7 @@ class OAuthInvalidRefreshTokenError extends RestApiError {
 
 class GraphQLNotFoundError extends ApolloError {
   constructor(message) {
-    super(message || "Unable to retrieve the requested resource");
+    super(message || "Unable to retrieve the requested resource!");
   }
 }
 

--- a/packages/server/gql/definitions/enums/ApplicationFieldType.graphql
+++ b/packages/server/gql/definitions/enums/ApplicationFieldType.graphql
@@ -1,17 +1,17 @@
 """
-The allowed types for application fields (subject to change)
+The allowed types for application fields (subject to change).
 """
 enum ApplicationFieldType {
   """
-  The application field type is a string
+  The application field type is a string.
   """
   STRING
   """
-  The application field type is a number
+  The application field type is a number.
   """
   NUMBER
   """
-  The application field type is a file
+  The application field type is a file.
   """
   FILE
 }

--- a/packages/server/gql/definitions/enums/ApplicationFieldType.graphql
+++ b/packages/server/gql/definitions/enums/ApplicationFieldType.graphql
@@ -3,15 +3,15 @@ The allowed types for application fields (subject to change)
 """
 enum ApplicationFieldType {
   """
-  The field type is a string
+  The application field type is a string
   """
   STRING
   """
-  The field type is a number
+  The application field type is a number
   """
   NUMBER
   """
-  The field type is a file
+  The application field type is a file
   """
   FILE
 }

--- a/packages/server/gql/definitions/enums/ApplicationFieldType.graphql
+++ b/packages/server/gql/definitions/enums/ApplicationFieldType.graphql
@@ -1,0 +1,17 @@
+"""
+The allowed types for application fields (subject to change)
+"""
+enum ApplicationFieldType {
+  """
+  The field type is a string
+  """
+  STRING
+  """
+  The field type is a number
+  """
+  NUMBER
+  """
+  The field type is a file
+  """
+  FILE
+}

--- a/packages/server/gql/definitions/enums/ApplicationStatus.graphql
+++ b/packages/server/gql/definitions/enums/ApplicationStatus.graphql
@@ -3,19 +3,19 @@ Different application statuses.
 """
 enum ApplicationStatus {
   """
-  The user has applied to the event.
+  The application has been submitted.
   """
   APPLIED
   """
-  The user has been accepted to the event.
+  The application has been accepted.
   """
   ACCEPTED
   """
-  The user has been rejected from the event.
+  The application has been rejected.
   """
   REJECTED
   """
-  The user has been put on the waiting list for the event.
+  The application has been placed on waiting list.
   """
   WAITING_LIST
 }

--- a/packages/server/gql/definitions/enums/ApplicationStatus.graphql
+++ b/packages/server/gql/definitions/enums/ApplicationStatus.graphql
@@ -1,0 +1,21 @@
+"""
+Different application statuses.
+"""
+enum ApplicationStatus {
+  """
+  The user has applied to the event.
+  """
+  APPLIED
+  """
+  The user has been accepted to the event.
+  """
+  ACCEPTED
+  """
+  The user has been rejected from the event.
+  """
+  REJECTED
+  """
+  The user has been put on the waiting list for the event.
+  """
+  WAITING_LIST
+}

--- a/packages/server/gql/definitions/interfaces/User.graphql
+++ b/packages/server/gql/definitions/interfaces/User.graphql
@@ -28,3 +28,7 @@ interface User {
   """
   oauthInfo: OAuthInfo!
 }
+
+extend type QueryRoot {
+  user: User!
+}

--- a/packages/server/gql/definitions/interfaces/User.graphql
+++ b/packages/server/gql/definitions/interfaces/User.graphql
@@ -30,5 +30,5 @@ interface User {
 }
 
 extend type QueryRoot {
-  user: User!
+  user: User
 }

--- a/packages/server/gql/definitions/types/Application.graphql
+++ b/packages/server/gql/definitions/types/Application.graphql
@@ -13,13 +13,6 @@ extend type MutationRoot {
     event: String!
     input: ApplicationInput!
   ): ApplicationCreatePayload!
-  """
-  Updates a user's application to an event
-  """
-  updateApplication(
-    event: String!
-    input: ApplicationInput!
-  ): ApplicationUpdatePayload!
 }
 
 type Application {
@@ -50,10 +43,6 @@ type ApplicationFieldResponse {
   The response of the applicant to the field
   """
   answer: String!
-}
-
-type ApplicationUpdatePayload {
-  application: Application
 }
 
 type ApplicationCreatePayload {

--- a/packages/server/gql/definitions/types/Application.graphql
+++ b/packages/server/gql/definitions/types/Application.graphql
@@ -1,0 +1,76 @@
+extend type QueryRoot {
+  """
+  Returns the current user's application to a specific event
+  """
+  application(event: String!): Application
+}
+
+extend type MutationRoot {
+  """
+  Creates a new application to an event for the current user
+  """
+  createApplication(
+    event: String!
+    input: ApplicationInput!
+  ): ApplicationCreatePayload!
+  """
+  Updates a user's application to an event
+  """
+  updateApplication(
+    event: String!
+    input: ApplicationInput!
+  ): ApplicationUpdatePayload!
+}
+
+type Application {
+  """
+  The user has applied to the  application
+  """
+  status: ApplicationStatus
+  """
+  The users response to the application
+  """
+  response: [ApplicationFieldResponse!]
+  """
+  The date that the application was submitted
+  """
+  submissionDate: Date
+}
+
+type ApplicationFieldResponse {
+  """
+  The label of the application field
+  """
+  type: ApplicationFieldType!
+  """
+  The label of the application field
+  """
+  label: String!
+  """
+  The response of the applicant to the field
+  """
+  answer: String!
+}
+
+type ApplicationUpdatePayload {
+  application: Application
+}
+
+type ApplicationCreatePayload {
+  application: Application
+}
+
+input ApplicationInput {
+  response: [ApplicationFieldInput!]
+}
+
+input ApplicationFieldInput {
+  """
+  The label of the application field
+  """
+  label: String!
+  """
+  The response of the applicant to the field
+  """
+  answer: String!
+}

--- a/packages/server/gql/definitions/types/Application.graphql
+++ b/packages/server/gql/definitions/types/Application.graphql
@@ -1,46 +1,46 @@
 extend type QueryRoot {
   """
-  Returns the current user's application to a specific event
+  Returns a user's application to a specific event.
   """
-  application(event: String!): Application
+  application(eventSlug: String!): Application
 }
 
 extend type MutationRoot {
   """
-  Creates a new application to an event for the current user
+  Creates a new application to an event for the current user.
   """
   createApplication(
-    event: String!
+    eventSlug: String!
     input: ApplicationInput!
   ): ApplicationCreatePayload!
 }
 
 type Application {
   """
-  The user has applied to the  application
+  The user has applied to the  application.
   """
   status: ApplicationStatus
   """
-  The users response to the application
+  The user's response to the application.
   """
-  response: [ApplicationFieldResponse!]
+  response: [ApplicationFieldResponse!]!
   """
-  The date that the application was submitted
+  The date that the application was submitted.
   """
   submissionDate: Date
 }
 
 type ApplicationFieldResponse {
   """
-  The label of the application field
+  The label of the application field.
   """
   type: ApplicationFieldType!
   """
-  The label of the application field
+  The label of the application field.
   """
   label: String!
   """
-  The response of the applicant to the field
+  The response of the applicant to the field.
   """
   answer: String!
 }
@@ -50,16 +50,16 @@ type ApplicationCreatePayload {
 }
 
 input ApplicationInput {
-  response: [ApplicationFieldInput!]
+  response: [ApplicationFieldInput!]!
 }
 
 input ApplicationFieldInput {
   """
-  The label of the application field
+  The label of the application field.
   """
   label: String!
   """
-  The response of the applicant to the field
+  The response of the applicant to the field.
   """
   answer: String!
 }

--- a/packages/server/gql/definitions/types/Application.graphql
+++ b/packages/server/gql/definitions/types/Application.graphql
@@ -21,9 +21,9 @@ type Application {
   """
   status: ApplicationStatus
   """
-  The user's response to the application.
+  The user's responses to the application fields.
   """
-  response: [ApplicationFieldResponse!]!
+  responses: [ApplicationFieldResponse!]!
   """
   The date that the application was submitted.
   """
@@ -50,7 +50,7 @@ type ApplicationCreatePayload {
 }
 
 input ApplicationInput {
-  response: [ApplicationFieldInput!]!
+  responses: [ApplicationFieldInput!]!
 }
 
 input ApplicationFieldInput {

--- a/packages/server/gql/resolvers/index.js
+++ b/packages/server/gql/resolvers/index.js
@@ -2,10 +2,16 @@ const { merge } = require("lodash");
 
 // Type Resolvers
 const hackerResolvers = require("./types/Hacker");
+const applicationResolvers = require("./types/Application");
 
 // Interface Resolvers
 const userResolvers = require("./interfaces/User");
 
 const resolvers = {};
 
-module.exports = merge(resolvers, userResolvers, hackerResolvers);
+module.exports = merge(
+  resolvers,
+  userResolvers,
+  hackerResolvers,
+  applicationResolvers
+);

--- a/packages/server/gql/resolvers/index.js
+++ b/packages/server/gql/resolvers/index.js
@@ -1,6 +1,7 @@
 const { merge } = require("lodash");
 
 // Type Resolvers
+const adminResolvers = require("./types/Admin");
 const hackerResolvers = require("./types/Hacker");
 const applicationResolvers = require("./types/Application");
 
@@ -12,6 +13,7 @@ const resolvers = {};
 module.exports = merge(
   resolvers,
   userResolvers,
+  adminResolvers,
   hackerResolvers,
   applicationResolvers
 );

--- a/packages/server/gql/resolvers/interfaces/User.js
+++ b/packages/server/gql/resolvers/interfaces/User.js
@@ -3,7 +3,7 @@ const { DatabaseError } = require("../../../errors");
 module.exports = {
   User: {
     __resolveType(user, context, info) {
-      return "Hacker";
+      return upperCase(context.access.role);
     }
   },
   QueryRoot: {
@@ -12,3 +12,6 @@ module.exports = {
     }
   }
 };
+
+const upperCase = (str) =>
+  str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();

--- a/packages/server/gql/resolvers/interfaces/User.js
+++ b/packages/server/gql/resolvers/interfaces/User.js
@@ -1,5 +1,3 @@
-const { DatabaseError } = require("../../../errors");
-
 module.exports = {
   User: {
     __resolveType(user, context, info) {

--- a/packages/server/gql/resolvers/interfaces/User.js
+++ b/packages/server/gql/resolvers/interfaces/User.js
@@ -7,18 +7,17 @@ module.exports = {
     }
   },
   QueryRoot: {
-    async user(
-      parent,
-      args,
-      {
+    async user(parent, args, context) {
+      const {
         user,
         db: { User, OAuthUser }
-      }
-    ) {
+      } = context;
+
       const currentUser = await User.findOne({
         where: { id: user.id },
         include: OAuthUser
       });
+
       if (!currentUser) {
         throw new DatabaseError("Unable to find user");
       }

--- a/packages/server/gql/resolvers/interfaces/User.js
+++ b/packages/server/gql/resolvers/interfaces/User.js
@@ -1,7 +1,32 @@
+const { DatabaseError } = require("../../../errors");
+
 module.exports = {
   User: {
     __resolveType(user, context, info) {
       return "Hacker";
+    }
+  },
+  QueryRoot: {
+    async user(
+      parent,
+      args,
+      {
+        user,
+        db: { User, OAuthUser }
+      }
+    ) {
+      const currentUser = await User.findOne({
+        where: { id: user.id },
+        include: OAuthUser
+      });
+      if (!currentUser) {
+        throw new DatabaseError("Unable to find user");
+      }
+
+      return {
+        ...currentUser.dataValues,
+        oauthInfo: { role: currentUser.OAuthUser.role }
+      };
     }
   }
 };

--- a/packages/server/gql/resolvers/interfaces/User.js
+++ b/packages/server/gql/resolvers/interfaces/User.js
@@ -7,25 +7,8 @@ module.exports = {
     }
   },
   QueryRoot: {
-    async user(parent, args, context) {
-      const {
-        user,
-        db: { User, OAuthUser }
-      } = context;
-
-      const currentUser = await User.findOne({
-        where: { id: user.id },
-        include: OAuthUser
-      });
-
-      if (!currentUser) {
-        throw new DatabaseError("Unable to find user");
-      }
-
-      return {
-        ...currentUser.dataValues,
-        oauthInfo: { role: currentUser.OAuthUser.role }
-      };
+    user(parent, args, context) {
+      return Promise.resolve(context.user);
     }
   }
 };

--- a/packages/server/gql/resolvers/types/Admin.js
+++ b/packages/server/gql/resolvers/types/Admin.js
@@ -1,16 +1,9 @@
+const {
+  Hacker: { oauthInfo }
+} = require("./Hacker");
+
 module.exports = {
   Admin: {
-    oauthInfo(parent, args, context) {
-      return {
-        role: context.access.role,
-        scopes: context.access.scopes.map((scope) => {
-          const splitScopes = scope.split(":");
-          return {
-            entity: splitScopes[0],
-            permission: splitScopes[1].toUpperCase()
-          };
-        })
-      };
-    }
+    oauthInfo
   }
 };

--- a/packages/server/gql/resolvers/types/Admin.js
+++ b/packages/server/gql/resolvers/types/Admin.js
@@ -1,0 +1,16 @@
+module.exports = {
+  Admin: {
+    oauthInfo(parent, args, context) {
+      return {
+        role: context.access.role,
+        scopes: context.access.scopes.map((scope) => {
+          const splitScopes = scope.split(":");
+          return {
+            entity: splitScopes[0],
+            permission: splitScopes[1].toUpperCase()
+          };
+        })
+      };
+    }
+  }
+};

--- a/packages/server/gql/resolvers/types/Application.js
+++ b/packages/server/gql/resolvers/types/Application.js
@@ -29,7 +29,7 @@ module.exports = {
       const applicationResponse = {
         status: applicationDBResponse.status,
         submissionDate: applicationDBResponse.submissionDate,
-        response: applicationDBResponse.ApplicationFields.map(
+        responses: applicationDBResponse.ApplicationFields.map(
           ({ dataValues, ApplicationFieldResponse }) => ({
             type: dataValues.type,
             label: dataValues.label,
@@ -100,7 +100,7 @@ module.exports = {
               })
           );
 
-          input.response.forEach(({ label, answer }) => {
+          input.responses.forEach(({ label, answer }) => {
             if (!applicationTable[label]) {
               throw new GraphQLUserInputError(
                 `${label} is not a valid field for ${slug}`
@@ -137,7 +137,8 @@ module.exports = {
           return {
             application: {
               status: application.status,
-              response: input.response
+              responses: input.responses,
+              submissionDate: application.submissionDate
             }
           };
         });

--- a/packages/server/gql/resolvers/types/Application.js
+++ b/packages/server/gql/resolvers/types/Application.js
@@ -1,4 +1,9 @@
-const { DatabaseError, ValidationError } = require("../../../errors");
+const {
+  DatabaseError,
+  GraphQLNotFoundError,
+  GraphQLForbiddenError,
+  GraphQLUserInputError
+} = require("../../../errors");
 
 module.exports = {
   QueryRoot: {
@@ -18,7 +23,7 @@ module.exports = {
       });
 
       if (!applicationDBResponse) {
-        throw new DatabaseError(`No application found for ${slug}`);
+        throw new GraphQLNotFoundError(`No application found for ${slug}`);
       }
 
       const applicationResponse = {
@@ -52,11 +57,11 @@ module.exports = {
           });
 
           if (!event) {
-            throw new DatabaseError(`Could not find event ${slug}`);
+            throw new GraphQLNotFoundError(`Could not find event ${slug}`);
           }
 
           if (!event.requiresApplication) {
-            throw new DatabaseError(
+            throw new GraphQLUserInputError(
               `${event.name} does not require applications`
             );
           }
@@ -67,7 +72,7 @@ module.exports = {
             currentDate > event.applicationCloseDate ||
             currentDate < event.applicationOpenDate
           ) {
-            throw new ValidationError(
+            throw new GraphQLForbiddenError(
               `${event.name} is not accepting applications at this time`
             );
           }
@@ -97,7 +102,7 @@ module.exports = {
 
           input.response.forEach(({ label, answer }) => {
             if (!applicationTable[label]) {
-              throw new ValidationError(
+              throw new GraphQLUserInputError(
                 `${label} is not a valid field for ${slug}`
               );
             }
@@ -110,7 +115,7 @@ module.exports = {
           const userResponse = Object.values(applicationTable).filter(
             (field, i) => {
               if (field.required && !field.answer) {
-                throw new ValidationError(
+                throw new GraphQLUserInputError(
                   `${Object.keys(applicationTable)[i]} is a required field!`
                 );
               }

--- a/packages/server/gql/resolvers/types/Application.js
+++ b/packages/server/gql/resolvers/types/Application.js
@@ -48,16 +48,20 @@ module.exports = {
         db: { Event, ApplicationField, ApplicationFieldResponse, sequelize }
       }
     ) {
+      //TODO: evaluate specific event details (ie startDate, endDate, hasApplications)
       try {
         const newApplication = await sequelize.transaction(async (t) => {
           const event = await Event.findOne({
             where: { slug },
             include: ApplicationField
           });
-          const application = await event.createApplication({
-            userId: user.id,
-            status: "APPLIED"
-          });
+          const application = await event.createApplication(
+            {
+              userId: user.id,
+              status: "APPLIED"
+            },
+            { transaction: t }
+          );
 
           const applicationTable = {};
           event.ApplicationFields.forEach(
@@ -74,7 +78,8 @@ module.exports = {
           });
 
           const fieldResponse = await ApplicationFieldResponse.bulkCreate(
-            Object.values(applicationTable)
+            Object.values(applicationTable),
+            { transaction: t }
           );
 
           if (!fieldResponse) {

--- a/packages/server/gql/resolvers/types/Application.js
+++ b/packages/server/gql/resolvers/types/Application.js
@@ -1,0 +1,100 @@
+const { ForbiddenError } = require("apollo-server-express");
+const { hasPermission } = require("../../../oauth/scopes");
+const { DatabaseError } = require("../../../errors");
+
+module.exports = {
+  QueryRoot: {
+    async application(
+      parent,
+      { event: slug },
+      {
+        db: { Event, Application, ApplicationField },
+        user
+      }
+    ) {
+      const applicationDBResponse = await Application.findOne({
+        where: { userId: user.id },
+        include: [
+          { model: Event, where: { slug } },
+          { model: ApplicationField }
+        ]
+      });
+
+      if (!applicationDBResponse) {
+        throw new DatabaseError(`No application found for ${slug}`);
+      }
+
+      const applicationResponse = {
+        status: applicationDBResponse.status,
+        submissionDate: applicationDBResponse.submissionDate,
+        response: applicationDBResponse.ApplicationFields.map(
+          ({ dataValues, ApplicationFieldResponse }) => ({
+            type: dataValues.type,
+            label: dataValues.label,
+            answer: ApplicationFieldResponse.answer
+          })
+        )
+      };
+
+      return applicationResponse;
+    }
+  },
+  MutationRoot: {
+    async createApplication(
+      parent,
+      { event: slug, input },
+      {
+        user,
+        db: { Event, ApplicationField, ApplicationFieldResponse, sequelize }
+      }
+    ) {
+      try {
+        const newApplication = await sequelize.transaction(async (t) => {
+          const event = await Event.findOne({
+            where: { slug },
+            include: ApplicationField
+          });
+          const application = await event.createApplication({
+            userId: user.id,
+            status: "APPLIED"
+          });
+
+          const applicationTable = {};
+          event.ApplicationFields.forEach(
+            (field) =>
+              (applicationTable[field.label] = { applicationFieldId: field.id })
+          );
+
+          input.response.forEach(({ label, answer }) => {
+            if (!applicationTable[label]) {
+              throw new Error();
+            }
+            applicationTable[label]["answer"] = answer;
+            applicationTable[label]["applicationId"] = application.id;
+          });
+
+          const fieldResponse = await ApplicationFieldResponse.bulkCreate(
+            Object.values(applicationTable)
+          );
+
+          if (!fieldResponse) {
+            return Promise.reject();
+          }
+
+          return {
+            application: {
+              status: application.status,
+              response: input.response
+            }
+          };
+        });
+
+        return Promise.resolve(newApplication);
+      } catch (err) {
+        return Promise.reject(
+          new DatabaseError("Could not create a new application")
+        );
+      }
+    }
+  }
+};

--- a/packages/server/gql/resolvers/types/Application.js
+++ b/packages/server/gql/resolvers/types/Application.js
@@ -2,14 +2,13 @@ const { DatabaseError, ValidationError } = require("../../../errors");
 
 module.exports = {
   QueryRoot: {
-    async application(
-      parent,
-      { event: slug },
-      {
+    async application(parent, args, context) {
+      const { eventSlug: slug } = args;
+      const {
         db: { Event, Application, ApplicationField },
         user
-      }
-    ) {
+      } = context;
+
       const applicationDBResponse = await Application.findOne({
         where: { userId: user.id },
         include: [
@@ -38,14 +37,13 @@ module.exports = {
     }
   },
   MutationRoot: {
-    async createApplication(
-      parent,
-      { event: slug, input },
-      {
+    async createApplication(parent, args, context) {
+      const { eventSlug: slug, input } = args;
+      const {
         user,
         db: { Event, ApplicationField, ApplicationFieldResponse, sequelize }
-      }
-    ) {
+      } = context;
+
       try {
         const newApplication = await sequelize.transaction(async (t) => {
           const event = await Event.findOne({

--- a/packages/server/gql/resolvers/types/Hacker.js
+++ b/packages/server/gql/resolvers/types/Hacker.js
@@ -60,5 +60,28 @@ module.exports = {
           };
         });
     }
+  },
+  Hacker: {
+    // TODO: Seperate this for other roles such as admins and partners
+    oauthInfo(parent, args, context) {
+      const {
+        db: { OAuthUser }
+      } = context;
+      const { oauthUserId } = parent;
+
+      return OAuthUser.findOne({ where: { id: oauthUserId } }).then(
+        (oauthUser) => {
+          oauthUser.scopes = JSON.parse(oauthUser.scopes).map((scope) => {
+            const splitScopes = scope.split(":");
+            return {
+              entity: splitScopes[0],
+              permission: splitScopes[1].toUpperCase()
+            };
+          });
+
+          return oauthUser;
+        }
+      );
+    }
   }
 };

--- a/packages/server/gql/resolvers/types/Hacker.js
+++ b/packages/server/gql/resolvers/types/Hacker.js
@@ -62,26 +62,17 @@ module.exports = {
     }
   },
   Hacker: {
-    // TODO: Seperate this for other roles such as admins and partners
     oauthInfo(parent, args, context) {
-      const {
-        db: { OAuthUser }
-      } = context;
-      const { oauthUserId } = parent;
-
-      return OAuthUser.findOne({ where: { id: oauthUserId } }).then(
-        (oauthUser) => {
-          oauthUser.scopes = JSON.parse(oauthUser.scopes).map((scope) => {
-            const splitScopes = scope.split(":");
-            return {
-              entity: splitScopes[0],
-              permission: splitScopes[1].toUpperCase()
-            };
-          });
-
-          return oauthUser;
-        }
-      );
+      return {
+        role: context.access.role,
+        scopes: context.access.scopes.map((scope) => {
+          const splitScopes = scope.split(":");
+          return {
+            entity: splitScopes[0],
+            permission: splitScopes[1].toUpperCase()
+          };
+        })
+      };
     }
   }
 };

--- a/packages/server/gql/resolvers/types/Hacker.js
+++ b/packages/server/gql/resolvers/types/Hacker.js
@@ -1,31 +1,32 @@
 const { ForbiddenError } = require("apollo-server-express");
 const { hasPermission } = require("../../../oauth/scopes");
 const { DatabaseError } = require("../../../errors");
+
 module.exports = {
   QueryRoot: {
-    async hacker(
-      parent,
-      args,
-      {
+    async hacker(parent, args, context, info) {
+      const {
         access,
         db: { User, OAuthUser }
-      },
-      info
-    ) {
+      } = context;
+
       if (!hasPermission("hacker", "read", access.scopes)) {
         throw new ForbiddenError("Invalid permissions!");
       }
-      const dbResponse = await OAuthUser.findOne({
+
+      const oauthUser = await OAuthUser.findOne({
         where: { role: "HACKER" },
         include: {
           model: User,
           where: { id: args.id }
         }
       });
-      if (!dbResponse || !dbResponse.User) {
+
+      if (!oauthUser || !oauthUser.User) {
         throw new DatabaseError("Hacker not found");
       }
-      return dbResponse.User;
+
+      return oauthUser.User;
     }
   },
   MutationRoot: {

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -105,7 +105,7 @@ app.use(express.static(BUNDLE_DIR));
 // Database Synchronization
 // NOTE: We only do force true for dev.
 db.sequelize
-  .sync({ force: true })
+  .sync({ force: false })
   .then(() => {
     logger.info("Database has synchronized successfully!");
 

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -105,7 +105,7 @@ app.use(express.static(BUNDLE_DIR));
 // Database Synchronization
 // NOTE: We only do force true for dev.
 db.sequelize
-  .sync({ force: false })
+  .sync({ force: true })
   .then(() => {
     logger.info("Database has synchronized successfully!");
 

--- a/packages/server/oauth/controllers/oauth.controller.js
+++ b/packages/server/oauth/controllers/oauth.controller.js
@@ -111,7 +111,7 @@ module.exports = (db) => {
             firstName,
             lastName,
             password,
-            email
+            email: email.toLowerCase()
           },
           { transaction: t }
         );
@@ -157,7 +157,7 @@ module.exports = (db) => {
     try {
       const oauthClient = await checkOAuthClientFirstPartyByHost(db, hostname);
 
-      const user = await db.User.authenticate(email, password);
+      const user = await db.User.authenticate(email.toLowerCase(), password);
 
       const oauthUser = await user.getOAuthUser();
 
@@ -260,7 +260,9 @@ module.exports = (db) => {
 
   async function resetPasswordRequest(email) {
     try {
-      const user = await db.User.findOne({ where: { email } });
+      const user = await db.User.findOne({
+        where: { email: email.toLowerCase() }
+      });
 
       if (!user) {
         return Promise.reject(new RestApiError("User not found!"));

--- a/packages/server/oauth/controllers/oauth.controller.js
+++ b/packages/server/oauth/controllers/oauth.controller.js
@@ -98,28 +98,37 @@ module.exports = (db) => {
       const newUser = await db.sequelize.transaction(async (t) => {
         const scopes = getDefaultScopes("HACKER");
 
-        const oauthUser = await db.OAuthUser.create({
-          role: "HACKER",
-          scopes: JSON.stringify(scopes)
-        });
+        const oauthUser = await db.OAuthUser.create(
+          {
+            role: "HACKER",
+            scopes: JSON.stringify(scopes)
+          },
+          { transaction: t }
+        );
 
-        const user = await oauthUser.createUser({
-          firstName,
-          lastName,
-          password,
-          email
-        });
+        const user = await oauthUser.createUser(
+          {
+            firstName,
+            lastName,
+            password,
+            email
+          },
+          { transaction: t }
+        );
 
         const { accessToken, refreshToken } = createTokensForUser(user.id);
         const expiryDate = new Date(
           Date.now() + 1000 * REFRESH_TOKEN_EXPIRE_SECONDS
         );
 
-        await oauthUser.createOAuthRefreshToken({
-          clientId: oauthClient.id,
-          refreshToken,
-          expiryDate
-        });
+        await oauthUser.createOAuthRefreshToken(
+          {
+            clientId: oauthClient.id,
+            refreshToken,
+            expiryDate
+          },
+          { transaction: t }
+        );
 
         return {
           user,

--- a/packages/server/oauth/controllers/oauth.controller.js
+++ b/packages/server/oauth/controllers/oauth.controller.js
@@ -5,6 +5,7 @@ const crypto = require("crypto");
 
 const {
   RestApiError,
+  ValidationError,
   OAuthInvalidRefreshTokenError,
   OAuthClientNotRegisteredError,
   OAuthClientNotPrivilegedError

--- a/packages/server/oauth/index.js
+++ b/packages/server/oauth/index.js
@@ -24,7 +24,8 @@ module.exports = (db) => {
       const oauthUser = await user.getOAuthUser();
 
       const access = {
-        scopes: JSON.parse(oauthUser.scopes)
+        scopes: JSON.parse(oauthUser.scopes),
+        role: oauthUser.role
       };
 
       return Promise.resolve({

--- a/packages/server/oauth/scopes/index.js
+++ b/packages/server/oauth/scopes/index.js
@@ -1,5 +1,6 @@
-const scopes = require("./scopes");
+const { isArray } = require("lodash");
 
+const scopes = require("./scopes");
 const READ_SUFFIX = ":read";
 const WRITE_SUFFIX = ":write";
 
@@ -15,7 +16,23 @@ function hasPermission(type, level, scopes) {
   }
 }
 
+// Converts scopes to { entity, permission } format
+function formatScopes(scopes) {
+  if (!isArray(scopes)) {
+    scopes = JSON.parse(scopes);
+  }
+
+  return scopes.map((scope) => {
+    const [entity, permission] = scope.split(":");
+    return {
+      entity,
+      permission: permission.toUpperCase()
+    };
+  });
+}
+
 module.exports = {
   ...scopes,
+  formatScopes,
   hasPermission
 };


### PR DESCRIPTION
## Proposed Change
Add application functionality to the GraphQL API

### How did you do this?
Added the necessary types, queries and mutations to allow clients to create applications to events

### Why are you choosing this approach?
To let people apply!

### Any open questions you want to ask code reviewers?
No

### List of changes:

  - Add resolvers for `Hacker`, `User`, and `Admin`
  - Create new `Application` type
  - Add new queries and mutations to allow the submission and viewing of applications

## Pull Request Checklist:

  - [x] My submission passes all tests.
  - [x] I have lint my code locally prior to submission.
  - [x] I have written new tests for my core changes (where applicable).
  - [x] I have referenced all useful information (issues, tasks, etc) in the pull request.

