### PR TITLE
Add test database to CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,25 +6,34 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install NPM Dependencies
+          name: Install dependencies
           command: npm run bootstrap
       - run:
-          name: Check Code Style
+          name: Check code style
           command: npm run style
 
   test:
     docker:
       - image: circleci/node:latest
+        environment:
+          DB_ENVIRONMENT: test
+      - image: circleci/postgres:9.6.5-alpine-ram
     steps:
       - checkout
       - run:
-          name: Install NPM Dependencies
-          command: npm run bootstrap
+          name: Wait for PostgreSQL
+          command: dockerize -wait tcp://localhost:5432 -timeout 1m
       - run:
-          name: Build MJML Email Templates
-          command: npm run build-emails
+          name: Install dependencies
+          command: |
+            npm run bootstrap
+            sudo apt-get install postgresql-client
       - run:
-          name: Perform Unit Tests and Send Coverage Data
+          name: Create test database
+          command: |
+            psql -U postgres -h localhost -p 5432 -c "CREATE DATABASE \"qhacks-test-database\";"
+      - run:
+          name: Run tests and send coverage data
           command: npm run test-with-coverage
 
 workflows:

--- a/packages/server/db/config.js
+++ b/packages/server/db/config.js
@@ -31,6 +31,7 @@ const config = {
     ...options
   },
   test: {
+    username: "postgres",
     database: "qhacks-test-database",
     host: "localhost",
     dialect: "postgres",


### PR DESCRIPTION
## Proposed Change

This adds a test database to our Circle CI config so that our server tests can pass!

### How did you do this?

Using the `circleci/postgres:9.6.5-alpine-ram` image that CircleCI provides!

### Why are you choosing this approach?

Make our tests actually work!

### Any open questions you want to ask code reviewers?

Nope!

### List of changes:

  - Update our `config.yml`

## Pull Request Checklist:

  - [x] My submission passes all tests.
  - [x] I have lint my code locally prior to submission.
  - [x] I have written new tests for my core changes (where applicable).
  - [x] I have referenced all useful information (issues, tasks, etc) in the pull request.

