### PR TITLE
Add subscribe endpoint to REST API

### DIFF
--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -103,9 +103,8 @@ app.use(history());
 app.use(express.static(BUNDLE_DIR));
 
 // Database Synchronization
-// NOTE: We only do force true for dev.
 db.sequelize
-  .sync({ force: true })
+  .sync()
   .then(() => {
     logger.info("Database has synchronized successfully!");
 

--- a/packages/server/rest/controllers/mailing-list.controller.js
+++ b/packages/server/rest/controllers/mailing-list.controller.js
@@ -1,1 +1,63 @@
-module.exports = (db) => ({});
+const { NotFoundError, RestApiError } = require("../../errors");
+
+module.exports = (db) => ({
+  async createMailingListSubscription(eventSlug, mailingListSlug, email) {
+    const { Event, MailingList, MailingListSubscription, User } = db;
+
+    if (!eventSlug) {
+      return Promise.reject(new RestApiError("Please provide an event!", 400));
+    }
+
+    if (!mailingListSlug) {
+      return Promise.reject(new RestApiError("Please provide a list!", 400));
+    }
+
+    if (!email) {
+      return Promise.reject(new RestApiError("Please provide an email!", 400));
+    }
+
+    try {
+      const event = await Event.findOne({
+        where: { slug: eventSlug },
+        include: { model: MailingList, where: { slug: mailingListSlug } }
+      });
+
+      if (!event) {
+        return Promise.reject(
+          new NotFoundError(
+            `Event ${eventSlug} with list ${mailingListSlug} was not found!`
+          )
+        );
+      }
+
+      const user = await User.findOne({
+        where: { email: email.toLowerCase() }
+      });
+
+      await MailingListSubscription.create({
+        mailingListId: event.MailingLists[0].id,
+        userId: user && user.id ? user.id : null,
+        email: email.toLowerCase()
+      });
+
+      return Promise.resolve("OK");
+    } catch (err) {
+      if (err.name && err.name === "SequelizeValidationError") {
+        return Promise.reject(
+          new RestApiError("Please provide a valid email address!", 422)
+        );
+      } else if (err.name && err.name === "SequelizeUniqueConstraintError") {
+        return Promise.reject(
+          new RestApiError(
+            "Provided email address has already been signed up!",
+            400
+          )
+        );
+      }
+
+      return Promise.reject(
+        new RestApiError("An unexpected error occured.", 500)
+      );
+    }
+  }
+});

--- a/packages/server/rest/routes/mailing-list.routes.js
+++ b/packages/server/rest/routes/mailing-list.routes.js
@@ -5,9 +5,18 @@ const SUBSCRIBE = "subscribe";
 module.exports = (db) => {
   const mailingListApi = Router();
 
-  const { mailingList } = require("../controllers/mailing-list.controller")(db);
+  const {
+    createMailingListSubscription
+  } = require("../controllers/mailing-list.controller")(db);
 
-  mailingListApi.post(`/${SUBSCRIBE}/`, (req, res) => {});
+  mailingListApi.post(
+    `/${SUBSCRIBE}/`,
+    ({ body: { event, name, email } }, res) => {
+      return createMailingListSubscription(event, name, email)
+        .then(() => res.status(201).json("OK"))
+        .catch((err) => res.status(err.status).json(err));
+    }
+  );
 
   return mailingListApi;
 };


### PR DESCRIPTION
## Proposed Change
Add the `/subscribe` endpoint to the API to allow users to subscribe to mailing lists!

### How did you do this?
Finished the empty controller and route left by @RobertWSaunders

### Why are you choosing this approach?
To let people subscribe :sunglasses

### Any open questions you want to ask code reviewers?
No

### List of changes:

  - Add `subscribe` endpoint to REST API
  - Remove `force: true` from sequelize

## Pull Request Checklist:

  - [x] My submission passes all tests.
  - [x] I have lint my code locally prior to submission.
  - [x] I have written new tests for my core changes (where applicable).
  - [x] I have referenced all useful information (issues, tasks, etc) in the pull request.

