### PR TITLE
Add application reviews to GraphQL API

### DIFF
--- a/packages/server/__tests__/config/seed-test-database.js
+++ b/packages/server/__tests__/config/seed-test-database.js
@@ -155,6 +155,7 @@ async function createApplicationFields() {
       type: "CHECKBOX",
       label: "Field 1",
       shortLabel: "Field 1",
+      createdAt: new Date(1980, 1, 1),
       required: true
     },
     {
@@ -162,6 +163,7 @@ async function createApplicationFields() {
       type: "CHECKBOX",
       label: "Field 2",
       shortLabel: "Field 2",
+      createdAt: new Date(1980, 1, 2),
       required: false
     },
     {
@@ -169,6 +171,7 @@ async function createApplicationFields() {
       type: "CHECKBOX",
       label: "Field 3",
       shortLabel: "Field 3",
+      createdAt: new Date(1980, 1, 3),
       required: true
     }
   ]);

--- a/packages/server/__tests__/gql/resolvers/types/Application.test.js
+++ b/packages/server/__tests__/gql/resolvers/types/Application.test.js
@@ -44,12 +44,14 @@ describe("Application Type", () => {
   it("queries for the current users application to an event", async () => {
     const { query } = await graphqlClient();
 
-    const { data } = await query({
+    const res = await query({
       query: GET_USER_APPLICATION_FOR_EVENT,
       variables: {
         eventSlug: "qhacks-2019"
       }
     });
+
+    const { data } = res;
 
     expect(data.application.status).toBe("APPLIED");
     expect(data.application.responses).toHaveLength(3);
@@ -69,7 +71,7 @@ describe("Application Type", () => {
 
     const { mutate } = await graphqlClient(user);
 
-    const { data } = await mutate({
+    const res = await mutate({
       mutation: CREATE_APPLICATION_FOR_EVENT,
       variables: {
         eventSlug: "qhacks-2019",
@@ -91,6 +93,8 @@ describe("Application Type", () => {
         }
       }
     });
+
+    const { data } = res;
 
     expect(data.applicationCreate.application.status).toBe("APPLIED");
     expect(data.applicationCreate.application.responses).toHaveLength(3);

--- a/packages/server/__tests__/gql/resolvers/types/Application.test.js
+++ b/packages/server/__tests__/gql/resolvers/types/Application.test.js
@@ -15,7 +15,7 @@ const GET_USER_APPLICATION_FOR_EVENT = gql`
 `;
 
 const GET_ALL_APPLICATIONS_FOR_EVENT = gql`
-  query GetAllApplications($eventSlug: String!, $after: ID, $first: Int) {
+  query GetAllApplications($eventSlug: String!, $after: Date, $first: Int) {
     applications(eventSlug: $eventSlug, after: $after, first: $first) {
       id
       status
@@ -286,13 +286,20 @@ describe("Application Type", () => {
 
     const { data: response1 } = await query({
       query: GET_ALL_APPLICATIONS_FOR_EVENT,
-      variables: { eventSlug: "qhacks-2019", first: 1, after: null }
+      variables: {
+        eventSlug: "qhacks-2019",
+        first: 1,
+        after: new Date(1, 1, 1)
+      }
     });
 
     expect(response1.applications).toBeDefined();
     expect(response1.applications).toHaveLength(1);
     expect(response1.applications[0]).toEqual(
-      expect.objectContaining({ status: "APPLIED", id: existingApplication.id })
+      expect.objectContaining({
+        status: "APPLIED",
+        id: existingApplication.id
+      })
     );
 
     // Query for the newly created application
@@ -302,7 +309,7 @@ describe("Application Type", () => {
       variables: {
         eventSlug: "qhacks-2019",
         first: 1,
-        after: existingApplication.id
+        after: existingApplication.createdAt
       }
     });
 

--- a/packages/server/__tests__/gql/resolvers/types/Application.test.js
+++ b/packages/server/__tests__/gql/resolvers/types/Application.test.js
@@ -277,11 +277,12 @@ describe("Application Type", () => {
       where: { email: "admin@test.com" }
     });
 
-    const existingApplication = await db.Application.findOne({});
-    const newApplication = await db.Application.create({
+    const newApplication = await db.Application.findOne({});
+    const oldApplication = await db.Application.create({
       userId: hacker.id,
       eventId: event.id,
-      status: "APPLIED"
+      status: "APPLIED",
+      submissionDate: new Date(1980, 1, 1)
     });
 
     const { query } = await graphqlClient(admin);
@@ -302,7 +303,7 @@ describe("Application Type", () => {
     expect(response1.applications[0]).toEqual(
       expect.objectContaining({
         status: "APPLIED",
-        id: existingApplication.id
+        id: oldApplication.id
       })
     );
 
@@ -313,7 +314,7 @@ describe("Application Type", () => {
       variables: {
         eventSlug: "qhacks-2019",
         first: 1,
-        after: existingApplication.createdAt
+        after: oldApplication.submissionDate
       }
     });
 

--- a/packages/server/__tests__/gql/resolvers/types/ApplicationReview.test.js
+++ b/packages/server/__tests__/gql/resolvers/types/ApplicationReview.test.js
@@ -76,8 +76,7 @@ describe("ApplicationReview Type", () => {
       variables: { eventSlug: "qhacks-2019" }
     });
 
-    expect(data).toHaveProperty("applications");
-    expect(data.applications).toBeNull();
+    expect(data).toBeNull();
     expect(errors).toHaveLength(1);
     expect(errors[0]).toEqual(
       expect.objectContaining({

--- a/packages/server/__tests__/gql/resolvers/types/ApplicationReview.test.js
+++ b/packages/server/__tests__/gql/resolvers/types/ApplicationReview.test.js
@@ -1,0 +1,110 @@
+const { gql } = require("apollo-server-express");
+const { db, graphqlClient } = global;
+
+const ALL_APPLICATIONS_QUERY = gql`
+  query GetAllApplications($eventSlug: String!) {
+    applications(eventSlug: $eventSlug) {
+      id
+      reviews {
+        score
+        reviewedBy {
+          firstName
+        }
+      }
+    }
+  }
+`;
+
+const CREATE_APPLICATION_REVIEW_MUTATION = gql`
+  mutation CreateApplicationReviewMutation(
+    $applicationId: ID!
+    $input: ApplicationReviewInput!
+  ) {
+    applicationReviewCreate(applicationId: $applicationId, input: $input) {
+      applicationReview {
+        score
+        reviewedAt
+      }
+    }
+  }
+`;
+
+describe("ApplicationReview Type", () => {
+  it("is shown as a field from the Application type for admins", async () => {
+    const application = await db.Application.findOne();
+    const admin = await db.User.findOne({
+      where: { email: "admin@test.com" }
+    });
+
+    await db.ApplicationReview.create({
+      applicationId: application.id,
+      reviewerId: admin.id,
+      score: 4
+    });
+
+    const { query } = await graphqlClient(admin);
+    const { data } = await query({
+      query: ALL_APPLICATIONS_QUERY,
+      variables: { eventSlug: "qhacks-2019" }
+    });
+
+    expect(data.applications).toBeDefined();
+    expect(data.applications).toHaveLength(1);
+    expect(data.applications[0].reviews).toBeDefined();
+    expect(data.applications[0].reviews).toHaveLength(1);
+    expect(data.applications[0].reviews[0]).toEqual({
+      reviewedBy: { firstName: "Ross" },
+      score: 4
+    });
+  });
+
+  it("is inaccessible to non-admins", async () => {
+    const application = await db.Application.findOne();
+    const admin = await db.User.findOne({
+      where: { email: "admin@test.com" }
+    });
+
+    await db.ApplicationReview.create({
+      applicationId: application.id,
+      reviewerId: admin.id,
+      score: 4
+    });
+
+    const { query } = await graphqlClient();
+    const { data, errors } = await query({
+      query: ALL_APPLICATIONS_QUERY,
+      variables: { eventSlug: "qhacks-2019" }
+    });
+
+    expect(data).toHaveProperty("applications");
+    expect(data.applications).toBeNull();
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toEqual(
+      expect.objectContaining({
+        name: "GraphQLError",
+        message:
+          "Not authorized! You are not the required user role to perform this operation."
+      })
+    );
+  });
+
+  it("creates new reviews via applicationReviewCreate mutation", async () => {
+    const application = await db.Application.findOne();
+    const admin = await db.User.findOne({
+      where: { email: "admin@test.com" }
+    });
+
+    const { mutate } = await graphqlClient(admin);
+    const { data } = await mutate({
+      mutation: CREATE_APPLICATION_REVIEW_MUTATION,
+      variables: { applicationId: application.id, input: { score: 2 } }
+    });
+
+    expect(data.applicationReviewCreate).toBeDefined();
+    expect(data.applicationReviewCreate.applicationReview).toBeDefined();
+    expect(data.applicationReviewCreate.applicationReview.score).toBe(2);
+    expect(
+      data.applicationReviewCreate.applicationReview.reviewedAt.getTime()
+    ).toBeLessThanOrEqual(Date.now());
+  });
+});

--- a/packages/server/__tests__/gql/resolvers/types/ApplicationReview.test.js
+++ b/packages/server/__tests__/gql/resolvers/types/ApplicationReview.test.js
@@ -95,16 +95,18 @@ describe("ApplicationReview Type", () => {
     });
 
     const { mutate } = await graphqlClient(admin);
-    const { data } = await mutate({
+    const res = await mutate({
       mutation: CREATE_APPLICATION_REVIEW_MUTATION,
       variables: { applicationId: application.id, input: { score: 2 } }
     });
+
+    const { data } = res;
 
     expect(data.applicationReviewCreate).toBeDefined();
     expect(data.applicationReviewCreate.applicationReview).toBeDefined();
     expect(data.applicationReviewCreate.applicationReview.score).toBe(2);
     expect(
-      data.applicationReviewCreate.applicationReview.reviewedAt.getTime()
+      data.applicationReviewCreate.applicationReview.reviewedAt
     ).toBeLessThanOrEqual(Date.now());
   });
 });

--- a/packages/server/gql/definitions/inputs/ApplicationReviewInput.graphql
+++ b/packages/server/gql/definitions/inputs/ApplicationReviewInput.graphql
@@ -1,0 +1,6 @@
+input ApplicationReviewInput {
+  """
+  The score awarded in the review.
+  """
+  score: Int!
+}

--- a/packages/server/gql/definitions/types/Application.graphql
+++ b/packages/server/gql/definitions/types/Application.graphql
@@ -44,37 +44,3 @@ type Application {
   """
   reviews: [ApplicationReview!]!
 }
-
-type ApplicationFieldResponse {
-  """
-  The label of the application field.
-  """
-  type: ApplicationFieldType!
-  """
-  The label of the application field.
-  """
-  label: String!
-  """
-  The response of the applicant to the field.
-  """
-  answer: String!
-}
-
-type ApplicationCreatePayload {
-  application: Application
-}
-
-input ApplicationInput {
-  responses: [ApplicationFieldInput!]!
-}
-
-input ApplicationFieldInput {
-  """
-  The label of the application field.
-  """
-  label: String!
-  """
-  The response of the applicant to the field.
-  """
-  answer: String!
-}

--- a/packages/server/gql/definitions/types/Application.graphql
+++ b/packages/server/gql/definitions/types/Application.graphql
@@ -4,9 +4,17 @@ extend type QueryRoot {
   """
   application(eventSlug: String!): Application
   """
-  Returns all applications for a specific event
+  Returns all applications for a specific event.
   """
-  applications(eventSlug: String!, first: Int, after: Date): [Application!]
+  applications(eventSlug: String!, offset: Int, limit: Int): [Application!]!
+  """
+  Returns all applications for a specific event, omitting ones already reviewed by the signed in admin.
+  """
+  applicationsToReview(
+    eventSlug: String!
+    offset: Int
+    limit: Int
+  ): [Application!]!
 }
 
 extend type MutationRoot {
@@ -38,7 +46,7 @@ type Application {
   """
   The date that the application was submitted.
   """
-  submissionDate: Date
+  submissionDate: Date!
   """
   The reviews of the application.
   """

--- a/packages/server/gql/definitions/types/Application.graphql
+++ b/packages/server/gql/definitions/types/Application.graphql
@@ -24,6 +24,10 @@ Represents an application to an event.
 """
 type Application {
   """
+  The id of the application.
+  """
+  id: ID!
+  """
   The user has applied to the application.
   """
   status: ApplicationStatus!

--- a/packages/server/gql/definitions/types/Application.graphql
+++ b/packages/server/gql/definitions/types/Application.graphql
@@ -6,7 +6,7 @@ extend type QueryRoot {
   """
   Returns all applications for a specific event
   """
-  applications(eventSlug: String!, first: Int, after: ID): [Application!]
+  applications(eventSlug: String!, first: Int, after: Date): [Application!]
 }
 
 extend type MutationRoot {

--- a/packages/server/gql/definitions/types/Application.graphql
+++ b/packages/server/gql/definitions/types/Application.graphql
@@ -6,7 +6,7 @@ extend type QueryRoot {
   """
   Returns all applications for a specific event
   """
-  applications(eventSlug: String!): [Application!]
+  applications(eventSlug: String!, first: Int, after: ID): [Application!]
 }
 
 extend type MutationRoot {

--- a/packages/server/gql/definitions/types/Application.graphql
+++ b/packages/server/gql/definitions/types/Application.graphql
@@ -3,6 +3,10 @@ extend type QueryRoot {
   Returns a user's application to a specific event.
   """
   application(eventSlug: String!): Application
+  """
+  Returns all applications for a specific event
+  """
+  applications(eventSlug: String!): [Application!]
 }
 
 extend type MutationRoot {
@@ -30,5 +34,43 @@ type Application {
   """
   The date that the application was submitted.
   """
-  submissionDate: Date!
+  submissionDate: Date
+  """
+  The reviews of the application.
+  """
+  reviews: [ApplicationReview!]!
+}
+
+type ApplicationFieldResponse {
+  """
+  The label of the application field.
+  """
+  type: ApplicationFieldType!
+  """
+  The label of the application field.
+  """
+  label: String!
+  """
+  The response of the applicant to the field.
+  """
+  answer: String!
+}
+
+type ApplicationCreatePayload {
+  application: Application
+}
+
+input ApplicationInput {
+  responses: [ApplicationFieldInput!]!
+}
+
+input ApplicationFieldInput {
+  """
+  The label of the application field.
+  """
+  label: String!
+  """
+  The response of the applicant to the field.
+  """
+  answer: String!
 }

--- a/packages/server/gql/definitions/types/ApplicationReview.graphql
+++ b/packages/server/gql/definitions/types/ApplicationReview.graphql
@@ -22,14 +22,3 @@ extend type MutationRoot {
     input: ApplicationReviewInput!
   ): ApplicationReviewCreatePayload!
 }
-
-input ApplicationReviewInput {
-  """
-  The score awarded in the review.
-  """
-  score: Int!
-}
-
-type ApplicationReviewCreatePayload {
-  applicationReview: ApplicationReview
-}

--- a/packages/server/gql/definitions/types/ApplicationReview.graphql
+++ b/packages/server/gql/definitions/types/ApplicationReview.graphql
@@ -1,0 +1,34 @@
+"""
+Represents a review of an application.
+"""
+type ApplicationReview {
+  """
+  The score awarded in the review.
+  """
+  score: Int!
+  """
+  The date at which the review was performed.
+  """
+  reviewedAt: Date!
+  """
+  The admin who performed the review.
+  """
+  reviewedBy: Admin!
+}
+
+extend type MutationRoot {
+  ApplicationReviewCreate(
+    input: ApplicationReviewInput!
+  ): ApplicationReviewCreatePayload!
+}
+
+input ApplicationReviewInput {
+  """
+  The score awarded in the review.
+  """
+  score: Int!
+}
+
+type ApplicationReviewCreatePayload {
+  applicationReview: ApplicationReview
+}

--- a/packages/server/gql/definitions/types/ApplicationReview.graphql
+++ b/packages/server/gql/definitions/types/ApplicationReview.graphql
@@ -17,7 +17,8 @@ type ApplicationReview {
 }
 
 extend type MutationRoot {
-  ApplicationReviewCreate(
+  applicationReviewCreate(
+    applicationId: ID!
     input: ApplicationReviewInput!
   ): ApplicationReviewCreatePayload!
 }

--- a/packages/server/gql/definitions/types/ApplicationReviewCreatePayload.graphql
+++ b/packages/server/gql/definitions/types/ApplicationReviewCreatePayload.graphql
@@ -1,0 +1,9 @@
+"""
+Represents the response when an application review is created.
+"""
+type ApplicationReviewCreatePayload {
+  """
+  The application review that was created.
+  """
+  applicationReview: ApplicationReview
+}

--- a/packages/server/gql/resolvers/types/Application.js
+++ b/packages/server/gql/resolvers/types/Application.js
@@ -49,8 +49,8 @@ const applications = combineResolvers(
 
     if (args.after) {
       pagination.where = {
-        createdAt: {
-          [db.Sequelize.Op.gt]: args.after
+        submissionDate: {
+          [db.Sequelize.Op.gt]: new Date(args.after)
         }
       };
     }
@@ -71,7 +71,7 @@ const applications = combineResolvers(
           }
         ],
         ...pagination,
-        order: [["createdAt", "ASC"]]
+        order: [["submissionDate", "ASC"]]
       });
 
       return applicationsFromDB;
@@ -207,6 +207,7 @@ const applicationCreate = combineResolvers(
 );
 
 // responses resolver
+
 const responses = (parent, ctx, args) => {
   return (
     parent.responses ||

--- a/packages/server/gql/resolvers/types/Application.js
+++ b/packages/server/gql/resolvers/types/Application.js
@@ -59,7 +59,7 @@ const applications = combineResolvers(
 
     if (args.after) {
       pagination.where = {
-        id: {
+        createdAt: {
           [db.Sequelize.Op.gt]: args.after
         }
       };
@@ -77,7 +77,8 @@ const applications = combineResolvers(
             where: { slug }
           }
         ],
-        ...pagination
+        ...pagination,
+        order: [["createdAt", "ASC"]]
       });
 
       return applicationsFromDB;

--- a/packages/server/gql/resolvers/types/Application.js
+++ b/packages/server/gql/resolvers/types/Application.js
@@ -55,16 +55,35 @@ const applications = combineResolvers(
   async (parent, args, ctx, info) => {
     const { db } = ctx;
     const { eventSlug: slug } = args;
-    const applicationsFromDB = await db.Application.findAll({
-      include: [
-        {
-          model: db.Event,
-          where: { slug }
-        }
-      ]
-    });
+    const pagination = {};
 
-    return applicationsFromDB;
+    if (args.after) {
+      pagination.where = {
+        id: {
+          [db.Sequelize.Op.gt]: args.after
+        }
+      };
+    }
+
+    if (args.first) {
+      pagination.limit = args.first;
+    }
+
+    try {
+      const applicationsFromDB = await db.Application.findAll({
+        include: [
+          {
+            model: db.Event,
+            where: { slug }
+          }
+        ],
+        ...pagination
+      });
+
+      return applicationsFromDB;
+    } catch (err) {
+      throw new DatabaseError("Unable to retrieve applications at this time!");
+    }
   }
 );
 

--- a/packages/server/gql/resolvers/types/Application.js
+++ b/packages/server/gql/resolvers/types/Application.js
@@ -36,14 +36,7 @@ const application = combineResolvers(
 
     const applicationResponse = {
       status: application.status,
-      submissionDate: application.submissionDate,
-      responses: application.ApplicationFields.map(
-        ({ dataValues, ApplicationFieldResponse }) => ({
-          type: dataValues.type,
-          label: dataValues.shortLabel,
-          answer: ApplicationFieldResponse.answer
-        })
-      )
+      submissionDate: application.submissionDate
     };
 
     return applicationResponse;
@@ -75,6 +68,9 @@ const applications = combineResolvers(
           {
             model: db.Event,
             where: { slug }
+          },
+          {
+            model: db.ApplicationField
           }
         ],
         ...pagination,
@@ -215,9 +211,23 @@ const applicationCreate = combineResolvers(
   }
 );
 
+// responses resolver
+const responses = (parent, ctx, args) => {
+  return parent.ApplicationFields.map(
+    ({ dataValues, ApplicationFieldResponse }) => ({
+      type: dataValues.type,
+      label: dataValues.shortLabel,
+      answer: ApplicationFieldResponse.answer
+    })
+  );
+};
+
 // Resolver Map
 
 module.exports = {
+  Application: {
+    responses
+  },
   QueryRoot: {
     application,
     applications

--- a/packages/server/gql/resolvers/types/ApplicationReview.js
+++ b/packages/server/gql/resolvers/types/ApplicationReview.js
@@ -30,26 +30,36 @@ const applicationReviewCreate = combineResolvers(
 const reviews = combineResolvers(
   isAuthorized(null, "ADMIN"),
   async (parent, args, ctx, info) => {
-    const { db } = ctx;
-    const reviews = await db.ApplicationReview.findAll({
-      where: {
-        applicationId: parent.id
-      }
-    });
+    try {
+      const { db } = ctx;
+      const applicationReviews = await db.ApplicationReview.findAll({
+        where: {
+          applicationId: parent.id
+        }
+      });
 
-    return reviews;
+      return applicationReviews;
+    } catch (err) {
+      throw new DatabaseError(
+        "Unable to retrieve application reviews at this time!"
+      );
+    }
   }
 );
 
 // ApplicationField reviewedBy resolver
 
 const reviewedBy = async (parent, args, ctx, info) => {
-  const { db } = ctx;
-  const reviewedBy = await db.User.findOne({
-    where: { id: parent.reviewerId }
-  });
+  try {
+    const { db } = ctx;
+    const reviewer = await db.User.findOne({
+      where: { id: parent.reviewerId }
+    });
 
-  return reviewedBy;
+    return reviewer;
+  } catch (err) {
+    throw new DatabaseError("Unable to retrieve reviewers at this time!");
+  }
 };
 
 module.exports = {

--- a/packages/server/gql/resolvers/types/ApplicationReview.js
+++ b/packages/server/gql/resolvers/types/ApplicationReview.js
@@ -1,6 +1,6 @@
 const { combineResolvers } = require("graphql-resolvers");
 
-const { GraphQLUserInputError } = require("../../../errors");
+const { DatabaseError } = require("../../../errors");
 
 const { isAuthorized } = require("../generics");
 
@@ -18,7 +18,9 @@ const applicationReviewCreate = combineResolvers(
       });
       return { applicationReview: res };
     } catch (err) {
-      throw new GraphQLUserInputError(err.message);
+      throw new DatabaseError(
+        "Unable to create an application review at this time!"
+      );
     }
   }
 );

--- a/packages/server/gql/resolvers/types/ApplicationReview.js
+++ b/packages/server/gql/resolvers/types/ApplicationReview.js
@@ -1,7 +1,9 @@
 const { combineResolvers } = require("graphql-resolvers");
 
-const { DatabaseError } = require("../../../errors");
-
+const {
+  GraphQLInternalServerError,
+  GRAPHQL_ERROR_CODES
+} = require("../../../errors/graphql-errors");
 const { isAuthorized } = require("../generics");
 
 // Mutation Root Resolver
@@ -18,8 +20,9 @@ const applicationReviewCreate = combineResolvers(
       });
       return { applicationReview: res };
     } catch (err) {
-      throw new DatabaseError(
-        "Unable to create an application review at this time!"
+      throw new GraphQLInternalServerError(
+        "Unable to create an application review at this time!",
+        GRAPHQL_ERROR_CODES.INTERNAL_SERVER_ERROR
       );
     }
   }
@@ -40,8 +43,9 @@ const reviews = combineResolvers(
 
       return applicationReviews;
     } catch (err) {
-      throw new DatabaseError(
-        "Unable to retrieve application reviews at this time!"
+      throw new GraphQLInternalServerError(
+        "Unable to retrieve application reviews at this time!",
+        GRAPHQL_ERROR_CODES.INTERNAL_SERVER_ERROR
       );
     }
   }
@@ -58,7 +62,10 @@ const reviewedBy = async (parent, args, ctx, info) => {
 
     return reviewer;
   } catch (err) {
-    throw new DatabaseError("Unable to retrieve reviewers at this time!");
+    throw new GraphQLInternalServerError(
+      "Unable to retrieve reviewers at this time!",
+      GRAPHQL_ERROR_CODES.INTERNAL_SERVER_ERROR
+    );
   }
 };
 

--- a/packages/server/gql/resolvers/types/ApplicationReview.js
+++ b/packages/server/gql/resolvers/types/ApplicationReview.js
@@ -1,0 +1,63 @@
+const { combineResolvers } = require("graphql-resolvers");
+
+const { GraphQLUserInputError } = require("../../../errors");
+
+const { isAuthorized } = require("../generics");
+
+// Mutation Root Resolver
+
+const applicationReviewCreate = combineResolvers(
+  isAuthorized(null, "ADMIN"),
+  async (parent, args, ctx, info) => {
+    const { db, user } = ctx;
+    try {
+      const res = db.ApplicationReview.create({
+        applicationId: args.applicationId,
+        reviewerId: user.id,
+        ...args.input
+      });
+      return { applicationReview: res };
+    } catch (err) {
+      throw new GraphQLUserInputError(err.message);
+    }
+  }
+);
+
+// Application reviews resolvers
+
+const reviews = combineResolvers(
+  isAuthorized(null, "ADMIN"),
+  async (parent, args, ctx, info) => {
+    const { db } = ctx;
+    const reviews = await db.ApplicationReview.findAll({
+      where: {
+        applicationId: parent.id
+      }
+    });
+
+    return reviews;
+  }
+);
+
+// ApplicationField reviewedBy resolver
+
+const reviewedBy = async (parent, args, ctx, info) => {
+  const { db } = ctx;
+  const reviewedBy = await db.User.findOne({
+    where: { id: parent.reviewerId }
+  });
+
+  return reviewedBy;
+};
+
+module.exports = {
+  Application: {
+    reviews
+  },
+  ApplicationReview: {
+    reviewedBy
+  },
+  MutationRoot: {
+    applicationReviewCreate
+  }
+};

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -99,4 +99,5 @@ db()
   })
   .catch((err) => {
     logger.error("Error! Cannot start server.", err);
+    console.log(err);
   });

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -99,5 +99,4 @@ db()
   })
   .catch((err) => {
     logger.error("Error! Cannot start server.", err);
-    console.log(err);
   });


### PR DESCRIPTION
## Proposed Change
Allow admins to create and read application reviews through our GraphQL API

Fixes: #231 

### How did you do this?
Added a new `ApplicationReview` types and updated the `Application`, `QueryRoot` and `MutationRoot` types accordingly

### Why are you choosing this approach?
For consistency

### Any open questions you want to ask code reviewers?
No

### List of changes:

  - Add `ApplicationReview` type to GraphQL API
  - Update related types in the API
  - Add and update tests

## Pull Request Checklist:

  - [x] My submission passes all tests.
  - [x] I have lint my code locally prior to submission.
  - [x] I have written new tests for my core changes (where applicable).
  - [x] I have referenced all useful information (issues, tasks, etc) in the pull request.

