### PR TITLE
Fix date validation for birthday input in application form

### DIFF
--- a/packages/client/components/Apply/ApplicationForm.js
+++ b/packages/client/components/Apply/ApplicationForm.js
@@ -275,7 +275,7 @@ class ApplicationForm extends Component {
         message: "Please enter a valid phone number"
       },
       birthday: {
-        regex: /^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]$/,
+        regex: /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/,
         stepNum: 1,
         message: "Please enter a valid date"
       },

--- a/packages/client/components/Apply/Step2.js
+++ b/packages/client/components/Apply/Step2.js
@@ -115,6 +115,8 @@ const Step2 = (props) => {
                 id="birthday"
                 key="birthday"
                 type="date"
+                placeholder="YYYY-MM-DD"
+                pattern="^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
                 value={props.applicationAnswers.birthday}
                 onChange={(e) =>
                   props.setApplicationAnswer("birthday", e.target.value)


### PR DESCRIPTION
## Proposed Change
Fix regex for validating that the birthday is in `yyyy-mm-dd` format

### How did you do this?
Added a `pattern` attribute to the date input which ensures that the input is in `yyyy-mm-dd`

### Why are you choosing this approach?
[This resource](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date#Handling_browser_support) suggests it as a work around for the problem that we are facing. For reference, in safari this is what the date input looks like 
![image](https://user-images.githubusercontent.com/11237799/50730687-15de6480-1121-11e9-9ea3-7cae142fa55f.png) so adding a `YYYY-MM-DD` placeholder will be helpful for users (credit to @rosslh in #217) 


### Any open questions you want to ask code reviewers?
No

### List of changes:

  - Update regex validation for birthday field

## Pull Request Checklist:

  - [x] My submission passes all tests.
  - [x] I have lint my code locally prior to submission.
  - [x] I have written new tests for my core changes (where applicable).
  - [x] I have referenced all useful information (issues, tasks, etc) in the pull request.

