### PR TITLE
Add default date to birthday date picker

### DIFF
--- a/packages/client/components/Apply/Step2.js
+++ b/packages/client/components/Apply/Step2.js
@@ -121,6 +121,9 @@ const Step2 = (props) => {
               <label htmlFor="birthday">Birthday</label>
               <Flatpickr
                 value={toDate(props.applicationAnswers.birthday)}
+                options={{
+                  defaultDate: `${new Date().getFullYear() - 20}-01-01`
+                }}
                 onChange={(date) =>
                   props.setApplicationAnswer(
                     "birthday",


### PR DESCRIPTION
## Proposed Change

Makes the default date for the birthday input closer to applicants' actual birthdays

### How did you do this?

Make default date the present minus 20 years

### Why are you choosing this approach?

More convenient for users

### Any open questions you want to ask code reviewers?

No

### List of changes:

  - title

## Pull Request Checklist:

  - [x] My submission passes all tests.
  - [x] I have lint my code locally prior to submission.
  - [x] I have written new tests for my core changes (where applicable).
  - [x] I have referenced all useful information (issues, tasks, etc) in the pull request.

