### PR TITLE
Fix apollo link for unauthenticated requests

### DIFF
--- a/packages/client/ApolloClient.js
+++ b/packages/client/ApolloClient.js
@@ -26,6 +26,8 @@ const CLIENT_NAME = isProd
     ? "dashboard-web-client-staging"
     : "dashboard-web-dev";
 
+const UNAUTHENTICATED_ERROR_CODE = "UNAUTHENTICATED";
+
 // Gets a new access token using an existing refresh token
 const getNewAccessToken = () => {
   console.log("[Token Refresh Info]: Attempting to refresh access token!");
@@ -65,7 +67,7 @@ const apolloClientSetup = async () => {
       if (graphQLErrors) {
         // Check for an unauthenticated error and retry with refreshed token
         graphQLErrors.forEach((err) => {
-          if (err.extensions.code === 401) {
+          if (err.extensions.code === UNAUTHENTICATED_ERROR_CODE) {
             getNewAccessToken()
               .then((res) => {
                 console.log(


### PR DESCRIPTION
## Proposed Change

Due to a small graphql change the apollo link for authentication errors no longer works. Fixed this 🔧 

### How did you do this?

Changed the code on the client side to be consistent with the server

### Why are you choosing this approach?

To fix small things

### Any open questions you want to ask code reviewers?

No

### List of changes:

  - Fix apollo link for authentication errors

## Pull Request Checklist:

  - [x] My submission passes all tests.
  - [x] I have lint my code locally prior to submission.
  - [x] I have written new tests for my core changes (where applicable).
  - [x] I have referenced all useful information (issues, tasks, etc) in the pull request.

